### PR TITLE
<Feat> 로그인 레이아웃 제작

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import Layout from './components/templates/Layout';
 import Board from './pages/board';
 import BoardDetail from './pages/board/detail';
 import BoardWrite from './pages/board/write';
+import Login from './pages/Login';
+import Register from './pages/Register';
 
 const App = () => {
   return (
@@ -14,7 +16,8 @@ const App = () => {
         <Route path='/board' element={<Board />} />
         <Route path='/board/:uuid' element={<BoardDetail />} />
         <Route path='/board/write' element={<BoardWrite />} />
-
+        <Route path='/login' element={<Login />} />
+        <Route path='/register' element={<Register />} />
         <Route path='/test/button' element={<ButtonTestPage></ButtonTestPage>}></Route>
         <Route path='/test/input' element={<InputTestPage></InputTestPage>}></Route>
       </Route>

--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -1,15 +1,20 @@
-
 import type { ButtonProps } from './Button.type';
 import { colors } from '../../../styles/color';
 
 const Button = ({
   variant = 'main',
   size = 'md',
+  shape = 'pill',
   children,
   disabled,
   fullWidth,
   ...props
 }: ButtonProps) => {
+  const shapeRadius = {
+    pill: '9999px', // 기존 값
+    rounded: '0.75rem', // 새 값 (12 px 정도)
+  } as const;
+
   const sizeClassName = {
     sm: 'px-3 py-1 text-sm',
     md: 'px-4 py-2 text-base',
@@ -37,6 +42,14 @@ const Button = ({
       backgroundColor: disabled ? colors.grey02 : colors.grey02,
       color: disabled ? colors.grey40 : colors.black,
     },
+    grey: {
+      backgroundColor: disabled ? colors.grey20 : colors.grey40,
+      color: colors.white,
+    },
+    greyLight: {
+      backgroundColor: disabled ? colors.grey20 : '#E3E6E6',
+      color: disabled ? colors.grey40 : '#999999',
+    },
   };
 
   const { backgroundColor, color } = styleMap[variant];
@@ -47,7 +60,7 @@ const Button = ({
         backgroundColor,
         color,
         width: fullWidth ? '100%' : undefined,
-        borderRadius: '9999px',
+        borderRadius: shapeRadius[shape],
         fontWeight: 500,
         transition: 'all 0.2s ease-in-out',
       }}
@@ -61,4 +74,3 @@ const Button = ({
 };
 
 export default Button;
-

--- a/src/components/atoms/button/Button.type.ts
+++ b/src/components/atoms/button/Button.type.ts
@@ -1,9 +1,11 @@
-export type ButtonVariant = 'main' | 'sub' | 'basic' | 'danger';
+export type ButtonVariant = 'main' | 'sub' | 'basic' | 'danger' | 'grey' | 'greyLight';
 export type ButtonSize = 'sm' | 'md' | 'lg';
+export type ButtonShape = 'pill' | 'rounded';
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
   size?: ButtonSize;
+  shape?: ButtonShape;
   disabled: boolean;
   fullWidth: boolean;
 }

--- a/src/components/atoms/input/Input.tsx
+++ b/src/components/atoms/input/Input.tsx
@@ -1,4 +1,4 @@
-import type { InputProps } from './Input.type';
+import type { InputProps, InputVariant } from './Input.type';
 import { colors } from '../../../styles/color';
 
 const Input = ({
@@ -12,10 +12,9 @@ const Input = ({
   value,
   ...props
 }: InputProps) => {
-  const baseClass = 'px-4 py-2 text-sm';
   const disabled = props.disabled;
 
-  const variantStyleMap: Record<typeof variant, React.CSSProperties> = {
+  const variantStyleMap: Record<InputVariant, React.CSSProperties> = {
     field: {
       backgroundColor: colors.grey02,
       border: `1px solid ${colors.mju_primary}`,
@@ -32,6 +31,19 @@ const Input = ({
       backgroundColor: '#ffffff',
       borderBottom: `1px solid ${colors.grey20}`,
     },
+    outlined: {
+      backgroundColor: colors.white,
+      outline: `2px solid ${colors.grey10}`,
+      outlineOffset: '-2px',
+      borderRadius: '0.75rem',
+      border: 'none',
+    },
+  };
+  const variantExtraClass: Record<InputVariant, string> = {
+    field: 'px-4 py-2 text-sm',
+    searchbar: 'px-4 py-2 text-sm',
+    labelfield: 'px-4 py-2 text-sm',
+    outlined: 'p-3 text-base',
   };
 
   const wrapperStyle: React.CSSProperties = {
@@ -59,7 +71,7 @@ const Input = ({
       )}
 
       <div
-        className={`${baseClass} w-full`}
+        className={`w-full ${variantExtraClass[variant]}`}
         style={{
           ...wrapperStyle,
           ...(isMaxed && !error ? { backgroundColor: '#fee2e2', borderColor: colors.error } : {}),
@@ -68,7 +80,7 @@ const Input = ({
       >
         {icon && <span className='mr-2'>{icon}</span>}
         <input
-          className='bg-transparent w-full outline-none'
+          className='bg-transparent w-full outline-none placeholder:text-common-grey-scale-grey20'
           maxLength={maxLength}
           value={value}
           disabled={disabled}

--- a/src/components/atoms/input/Input.type.ts
+++ b/src/components/atoms/input/Input.type.ts
@@ -1,4 +1,4 @@
-export type InputVariant = 'field' | 'searchbar' | 'labelfield';
+export type InputVariant = 'field' | 'searchbar' | 'labelfield' | 'outlined';
 
 export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   variant?: InputVariant;

--- a/src/components/molecules/InputField/index.tsx
+++ b/src/components/molecules/InputField/index.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Input from '../../atoms/input/Input';
+
+interface InputFieldProps {
+  label: string;
+  placeholder: string;
+  type: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  error?: boolean;
+  helperText?: string;
+}
+
+const InputField: React.FC<InputFieldProps> = ({
+  label,
+  placeholder,
+  type,
+  value,
+  onChange,
+  error = false,
+  helperText,
+}) => {
+  return (
+    <div className='flex flex-col gap-2 w-full'>
+      <div className='flex items-center gap-6'>
+        <label className='text-blue-10 text-xl font-semibold whitespace-nowrap'>{label}</label>
+        <hr className='flex-1 border-t-2 border-blue-10 rounded-xl' />
+      </div>
+      <Input
+        type={type}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        variant='outlined'
+        error={error}
+        helperText={helperText}
+      />
+    </div>
+  );
+};
+
+export default InputField;

--- a/src/components/molecules/LoginButtons/index.tsx
+++ b/src/components/molecules/LoginButtons/index.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import Button from '../../atoms/button/Button';
+
+interface LoginButtonsProps {
+  loading?: boolean;
+  disabled?: boolean;
+  onSignUp?: () => void;
+}
+
+const LoginButtons: React.FC<LoginButtonsProps> = ({
+  loading = false,
+  disabled = false,
+  onSignUp,
+}) => {
+  const isLoginDisabled = disabled || loading;
+  const loginVariant = isLoginDisabled ? 'grey' : 'main';
+  return (
+    <div className='flex flex-col gap-3 w-full'>
+      {/* 1) 로그인 버튼 */}
+      <Button
+        type='submit'
+        variant={loginVariant}
+        size='lg'
+        shape='rounded'
+        disabled={isLoginDisabled}
+        fullWidth
+      >
+        로그인
+      </Button>
+
+      {/* 2) 회원가입 버튼 */}
+      <Button
+        type='button'
+        variant='greyLight'
+        size='lg'
+        shape='rounded'
+        disabled={false}
+        fullWidth
+        onClick={onSignUp}
+      >
+        회원가입
+      </Button>
+    </div>
+  );
+};
+
+export default LoginButtons;

--- a/src/components/organisms/LoginForm/index.tsx
+++ b/src/components/organisms/LoginForm/index.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import InputField from '../../molecules/InputField';
+import LoginButtons from '../../molecules/LoginButtons';
+import { useNavigate } from 'react-router-dom';
+
+const emailRegex = /^[\w.-]+@mju\.ac\.kr$/;
+
+const LoginForm: React.FC = () => {
+  const navigate = useNavigate();
+
+  const [id, setId] = useState('');
+  const [pw, setPw] = useState('');
+  const [emailError, setEmailError] = useState(false);
+
+  const formValid = emailRegex.test(id) && pw.trim() !== '';
+
+  const handleLogin = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    // 1) 이메일 형식 체크
+    if (!emailRegex.test(id)) {
+      alert('@mju.ac.kr 이메일만 로그인할 수 있습니다.');
+      setEmailError(true);
+      return;
+    }
+
+    // 2) 공백 체크
+    if (id.trim() === '' || pw.trim() === '') {
+      alert('아이디와 비밀번호를 모두 입력해주세요.');
+      return;
+    }
+
+    // 3) formValid가 false라면 방어적으로 종료
+    if (!formValid) return;
+
+    console.log('로그인 요청: ', { id, pw });
+  };
+
+  return (
+    <form className='flex flex-col mx-auto gap-12 w-[440px]' onSubmit={handleLogin}>
+      <InputField
+        label='이메일'
+        type='email'
+        placeholder='@mju.ac.kr'
+        value={id}
+        onChange={(e) => {
+          setId(e.target.value);
+          setEmailError(false);
+        }}
+        error={emailError}
+        helperText={emailError ? '학교 이메일 형식이 아닙니다.' : ''}
+      />
+      <InputField
+        label='비밀번호'
+        type='password'
+        placeholder='비밀번호를 입력하세요'
+        value={pw}
+        onChange={(e) => setPw(e.target.value)}
+      />
+      <form onSubmit={handleLogin} className='flex flex-col gap-y-6'>
+        <LoginButtons
+          loading={false}
+          onSignUp={() => navigate('/register')}
+          disabled={!formValid}
+        />
+      </form>
+    </form>
+  );
+};
+
+export default LoginForm;

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import LoginForm from '../../components/organisms/LoginForm';
+
+const Login: React.FC = () => {
+  return (
+    <div className='bg-grey-05 w-[1240px] min-h-screen flex flex-col p-12'>
+      {/* 제목: 왼쪽 정렬 */}
+      <p className='text-4xl font-bold text-blue-900 text-mju-primary'>로그인</p>
+
+      {/* 가운데 정렬 영역 */}
+      <div className='w-full flex justify-center items-cente'>
+        <div className='flex flex-col gap-6 w-[672px]'>
+          <p className='text-3xl font-bold text-mju-primary'>필수 정보</p>
+
+          {/* 하얀 박스: 로그인 폼 */}
+          <div className='flex w-full min-h-[480px] items-center bg-white p-6 rounded-xl'>
+            <LoginForm />
+          </div>
+
+          {/* 아이디/비밀번호 찾기 */}
+          <div className='flex justify-evenly'>
+            <p className='font-normal text-[#999999]'>아이디 찾기</p>
+            <p className='font-normal text-[#999999]'>|</p>
+            <p className='font-normal text-[#999999]'>비밀번호 찾기</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/pages/Register/index.tsx
+++ b/src/pages/Register/index.tsx
@@ -1,0 +1,5 @@
+const Register: React.FC = () => {
+  return <div>dd</div>;
+};
+
+export default Register;


### PR DESCRIPTION
#1 
Atomic 디자인 패턴을 기반으로 작업했습니다.
Button, Input 등 Atom 컴포넌트들을 활용하여 로그인 레이아웃을 제작하였습니다.
1. Input 컴포넌트에 variant='outlined' 를 추가했습니다.
2. Button 컴포넌트에 shape 속성을 추가하여 rounded를 두 타입 중 선택할 수 있게 했습니다.
3. 로그인 페이지
- 유효성 검사 (@mju.ac.kr 형식 + 공란 금지), 유효성 충족 시 버튼 활성화, alert() 피드백 제공 기능을 함께 구현했습니다.
- useState로 입력 상태를 관리하고  formValid를 통해 상태를 추적하도록 했습니다.
- width를 1240px 고정하였으며 피그마 디자인과 일치하도록 했습니다.
    <img width="1470" alt="image" src="https://github.com/user-attachments/assets/58d9ef05-9018-45b0-8c31-69f3e763a3b5" />
    
    아이디와 비밀번호 입력 시 로그인 버튼이 활성화됩니다.
    <img width="1470" alt="image" src="https://github.com/user-attachments/assets/ba8e05b9-e101-44dc-afef-aa4f4f72798d" />

전체 
<img width="929" alt="image" src="https://github.com/user-attachments/assets/894d5441-20e8-45d2-a0c5-3f4a1e149aac" />
