### PR TITLE
[Feat] 명대방송국 메인페이지에 연동 및 디자인 변경 및 주말 식단 예외처리

### DIFF
--- a/src/api/main/broadcast-api.ts
+++ b/src/api/main/broadcast-api.ts
@@ -1,9 +1,14 @@
 import apiClient from '../apiClient';
 import type { BroadcastData } from '../../types/broadcast/broadcastInfo';
 
-export const fetchBroadCastInfo = async (): Promise<BroadcastData> => {
+export const fetchBroadCastInfo = async (
+  page: number = 0,
+  size: number = 9,
+): Promise<BroadcastData> => {
   try {
-    const response = await apiClient.get('/broadcast');
+    const response = await apiClient.get('/broadcast', {
+      params: { page, size },
+    });
     return response.data;
   } catch (e) {
     console.log('방송국 정보 불러오는데 오류 발생', e);

--- a/src/api/main/broadcast-api.ts
+++ b/src/api/main/broadcast-api.ts
@@ -1,0 +1,12 @@
+import apiClient from '../apiClient';
+import type { BroadcastData } from '../../types/broadcast/broadcastInfo';
+
+export const fetchBroadCastInfo = async (): Promise<BroadcastData> => {
+  try {
+    const response = await apiClient.get('/broadcast');
+    return response.data;
+  } catch (e) {
+    console.log('방송국 정보 불러오는데 오류 발생', e);
+    throw e;
+  }
+};

--- a/src/components/molecules/mainpage/Meal/index.tsx
+++ b/src/components/molecules/mainpage/Meal/index.tsx
@@ -7,7 +7,7 @@ interface MealComponentProps {
 const MealComponent = ({ title, items, highlight }: MealComponentProps) => {
   return (
     <div
-      className={` border rounded-xl  ${highlight ? 'bg-grey-10 ' : 'bg-white'} shadow-sm w-full max-w-xs`}
+      className={` border rounded-xl  ${highlight ? 'bg-white ' : 'bg-white'} shadow-sm w-full `}
     >
       <div className='border-b border-mju-primary px-4 py-2'>
         <h2

--- a/src/components/molecules/user/LoginButtons/index.tsx
+++ b/src/components/molecules/user/LoginButtons/index.tsx
@@ -16,7 +16,6 @@ const LoginButtons: React.FC<LoginButtonsProps> = ({
   const loginVariant = isLoginDisabled ? 'grey' : 'main';
   return (
     <div className='flex flex-col gap-3 w-full'>
-      {/* 1) 로그인 버튼 */}
       <Button
         type='submit'
         variant={loginVariant}

--- a/src/components/organisms/sections/BroadcastSection.tsx
+++ b/src/components/organisms/sections/BroadcastSection.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import { fetchBroadCastInfo } from '../../../api/main/broadcast-api';
+import type { BroadcastContent } from '../../../types/broadcast/broadcastInfo';
+
+const BroadcastSection = () => {
+  const [broadcasts, setBroadcasts] = useState<BroadcastContent[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const page = 0;
+  const size = 9;
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const data = await fetchBroadCastInfo(page, size);
+        console.log(data);
+        setBroadcasts(data.data.content);
+      } catch (err) {
+        console.error('방송 데이터를 불러오는 데 실패했습니다.', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadData();
+  }, []);
+
+  return (
+    <section className='p-4'>
+      <h2 className='text-xl text-mju-primary font-bold mb-4'>명대뉴스</h2>
+
+      {loading ? (
+        <p className='text-sm text-gray-500'>로딩 중...</p>
+      ) : (
+        <div className='flex gap-4 overflow-x-auto mt-4'>
+          {broadcasts.map((item, index) => (
+            <div key={index} className='min-w-[320px] bg-white rounded-lg shadow-sm border p-2'>
+              <iframe
+                className='w-full h-48 rounded'
+                src={`https://www.youtube.com/embed/${extractYoutubeId(item.url)}`}
+                title={item.title}
+                allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture'
+                allowFullScreen
+              ></iframe>
+
+              <div className='mt-2 px-2'>
+                <h3 className='text-sm font-semibold truncate'>{item.title}</h3>
+                <p className='text-xs text-gray-500 truncate'>
+                  유튜브내에 적힌 설명이 어쩌구저쩌구
+                </p>
+                <p className='text-[10px] text-gray-400 mt-1'>{formatDate(item.publishedAt)}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default BroadcastSection;
+
+const extractYoutubeId = (url: string): string => {
+  const match = url.match(/v=([^&]+)/);
+  return match ? match[1] : '';
+};
+
+const formatDate = (isoDate: string): string => {
+  const date = new Date(isoDate);
+  return `${date.getFullYear()}.${(date.getMonth() + 1)
+    .toString()
+    .padStart(2, '0')}.${date.getDate().toString().padStart(2, '0')}`;
+};

--- a/src/components/organisms/sections/MealSection.tsx
+++ b/src/components/organisms/sections/MealSection.tsx
@@ -27,10 +27,17 @@ const MealSection = () => {
     저녁: [],
   });
 
+  //주말인 경우의 예외처리로직
+  const isWeekend = () => {
+    const day = new Date().getDay();
+    return day === 0 || day === 6;
+  };
+
   useEffect(() => {
     const fetchingMealSection = async () => {
       try {
         const response = await fetchMealInfo();
+        console.log(response.data);
         const todayStr = getTodayString();
         const meals = response.data.filter((item) => item.date === todayStr);
 
@@ -63,16 +70,18 @@ const MealSection = () => {
         </span>
       </div>
 
-      <div className='flex flex-col md:flex-row gap-4 justify-start'>
-        {(['아침', '점심', '저녁'] as const).map((meal) => (
+      {isWeekend() ? (
+        <div className='text-gray-400 text-sm'>주말에는 학식이 제공되지 않습니다.</div>
+      ) : (
+        <div className='w-full md:flex-row gap-4 justify-start'>
           <MealComponent
-            key={meal}
-            title={meal}
-            items={todayMeals[meal]}
-            highlight={current === meal}
+            key={current}
+            title={current}
+            items={todayMeals[current]}
+            highlight={true}
           />
-        ))}
-      </div>
+        </div>
+      )}
     </section>
   );
 };

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -1,14 +1,15 @@
-import NoticeSection from '../../components/organisms/sections/NoticeSection';
-import MealSection from '../../components/organisms/sections/MealSection';
-
-import NewsSection from '../../components/organisms/sections/NewsSection';
+import NoticeSection from '../../components/organisms/Sections/NoticeSection';
+import MealSection from '../../components/organisms/Sections/MealSection';
+import NewsSection from '../../components/organisms/Sections/NewsSection';
 import LayoutForMain from '../../components/templates/LayoutForMain';
+import BroadcastSection from '../../components/organisms/Sections/BroadcastSection';
 const Main = () => {
   return (
     <LayoutForMain>
       <MealSection />
       <NoticeSection />
       <NewsSection />
+      <BroadcastSection />
     </LayoutForMain>
   );
 };

--- a/src/types/broadcast/broadcastInfo.ts
+++ b/src/types/broadcast/broadcastInfo.ts
@@ -1,0 +1,17 @@
+export interface BroadcastContent {
+  title: string;
+  url: string;
+  thumbnailUrl: string;
+  playlistTitle: string;
+  publishedAt: string; // ISO 형식의 날짜 문자열
+}
+
+export interface BroadcastData {
+  content: BroadcastContent[];
+}
+
+export interface BroadcastResponse {
+  status: string;
+  data: BroadcastData;
+  timestamp: string;
+}


### PR DESCRIPTION
<img width="1920" height="991" alt="스크린샷 2025-08-03 오후 9 08 46" src="https://github.com/user-attachments/assets/30227df8-c4d0-4141-be4c-245563c27a02" />
<img width="1080" height="914" alt="스크린샷 2025-08-03 오후 9 08 55" src="https://github.com/user-attachments/assets/b369867a-214b-413a-beeb-64a194a34df8" />

1. 식단 관련 이슈가 있어서 수정했습니다. 주말에는 주는 정보가 없어서 아무것도 렌더링안되는 이슈 떄문에 예외처리를 해놨습니다.
2. 방송국 관련 정보는 유튜브 링크와 연동하여, 오른쪽으로 드래그가 되어 사용자로 하여금 쉽게 볼 수 있게 해놨습니다.
3. 