### PR TITLE
[Fix] navbar 내부 로그인,로그아웃 기능 추가 및 로그인 상태에 따른 게시판 보안기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "pretendard": "^1.3.9",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-hot-toast": "^2.5.2",
         "react-icons": "^5.5.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.6.2",
@@ -4050,6 +4051,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -6912,6 +6922,23 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "pretendard": "^1.3.9",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.6.2",

--- a/src/components/atoms/Button/Button.type.ts
+++ b/src/components/atoms/Button/Button.type.ts
@@ -2,6 +2,7 @@ export type ButtonVariant =
   | 'main'
   | 'sub'
   | 'basic'
+  | 'blue20'
   | 'blue35'
   | 'danger'
   | 'grey'

--- a/src/components/atoms/Button/ButtonActiveStyleMap.ts
+++ b/src/components/atoms/Button/ButtonActiveStyleMap.ts
@@ -13,6 +13,10 @@ const buttonActiveStyleMap: Record<string, React.CSSProperties> = {
     backgroundColor: colors.blue15,
     color: colors.white,
   },
+  blue20: {
+    backgroundColor: colors.blue20,
+    color: colors.white,
+  },
   blue35: {
     backgroundColor: colors.blue35,
     color: colors.white,

--- a/src/components/molecules/user/LoginButtons/index.tsx
+++ b/src/components/molecules/user/LoginButtons/index.tsx
@@ -30,7 +30,7 @@ const LoginButtons: React.FC<LoginButtonsProps> = ({
       {/* 2) 회원가입 버튼 */}
       <Button
         type='button'
-        variant='greyLight'
+        variant='blue20'
         size='lg'
         shape='rounded'
         disabled={false}

--- a/src/components/organisms/Navbar.tsx
+++ b/src/components/organisms/Navbar.tsx
@@ -1,113 +1,206 @@
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import logo from '../../assets/schoolLogo.png';
-import { HiMenu, HiX } from 'react-icons/hi'; // 햄버거/닫기 아이콘
+import { HiMenu, HiX } from 'react-icons/hi';
 import { useState } from 'react';
+import { FiLogIn, FiLogOut } from 'react-icons/fi';
+import { useAuthStore } from '../../store/useAuthStore';
 
 const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const { isLoggedIn, logout } = useAuthStore();
+  const navigate = useNavigate();
 
   const toggleMenu = () => setIsOpen((prev) => !prev);
+  const handleAuthClick = () => {
+    if (isLoggedIn) logout();
+    else navigate('/login');
+  };
+  const closeMenu = () => setIsOpen(false);
 
   return (
-    <nav className='bg-[#002f6c] p-3 z-50 w-full'>
-      <div className='md:max-w-[1200px] w-[90%] mx-auto flex justify-between items-center'>
-        <Link to='/'>
-          <div className='flex items-center gap-3'>
-            <img src={logo} alt='Logo' className='w-10 h-10' />
-            <div className='flex text-white text-xl font-bold no-underline'>
+    <nav className='bg-[#002f6c] h-14 w-full z-50 shadow-sm overflow-hidden'>
+      <div className='mx-auto md:max-w-[1200px] w-[90%] h-full px-4 flex items-center justify-between'>
+        {/* 브랜드 */}
+        <Link to='/' className='h-full'>
+          <div className='flex items-center h-full gap-3'>
+            <img src={logo} alt='Logo' className='w-8 h-8 block' />
+            <div className='flex text-white text-xl font-bold leading-none'>
               <span>MJ</span>
               <span className='text-sky-300'>S</span>
             </div>
           </div>
         </Link>
 
-        {/* 햄버거 버튼 (모바일) */}
-        <button className='md:hidden text-white text-2xl focus:outline-none' onClick={toggleMenu}>
-          {isOpen ? <HiX /> : <HiMenu />}
+        {/* 모바일: 햄버거 */}
+        <button
+          className='md:hidden h-10 w-10 grid place-items-center text-white rounded hover:bg-white/10 transition-colors leading-none'
+          onClick={toggleMenu}
+          aria-label={isOpen ? '메뉴 닫기' : '메뉴 열기'}
+        >
+          {isOpen ? <HiX size={20} /> : <HiMenu size={20} />}
         </button>
 
         {/* 데스크톱 메뉴 */}
-        <ul className='hidden md:flex gap-3 list-none text-white text-sm font-medium'>
+        <ul className='hidden md:flex items-center gap-1 list-none text-white text-sm font-medium leading-none'>
           <li>
-            <Link to='/department'>
-              <span className='px-3 py-2'>학과정보</span>
+            <Link
+              to='/department'
+              className='inline-flex items-center h-10 px-3 rounded-lg hover:bg-white/10'
+            >
+              학과정보
             </Link>
           </li>
           <li>
-            <Link to='/menu' className='p-3'>
+            <Link
+              to='/menu'
+              className='inline-flex items-center h-10 px-3 rounded-lg hover:bg-white/10'
+            >
               식단
             </Link>
           </li>
           <li>
-            <span className='px-3 py-2 rounded cursor-default text-white/60'>벼룩시장</span>
+            <span className='inline-flex items-center h-10 px-3 rounded-lg cursor-default text-white/60'>
+              벼룩시장
+            </span>
           </li>
           <li>
-            <span className='px-3 py-2 rounded cursor-default text-white/60'>제휴</span>
+            <span className='inline-flex items-center h-10 px-3 rounded-lg cursor-default text-white/60'>
+              제휴
+            </span>
           </li>
           <li>
-            <Link to='/notice' className='p-3'>
+            <Link
+              to='/notice'
+              className='inline-flex items-center h-10 px-3 rounded-lg hover:bg-white/10'
+            >
               공지사항
             </Link>
           </li>
           <li>
-            <Link to='/board' className='p-3'>
+            <Link
+              to='/board'
+              className='inline-flex items-center h-10 px-3 rounded-lg hover:bg-white/10'
+            >
               검색게시판
             </Link>
           </li>
           <li>
-            <span className='px-3 py-2 rounded cursor-default text-white/60'>취업후기</span>
+            <span className='inline-flex items-center h-10 px-3 rounded-lg cursor-default text-white/60'>
+              취업후기
+            </span>
           </li>
           <li>
             <a
               href='https://namu.wiki/w/%EB%AA%85%EC%A7%80%EB%8C%80%ED%95%99%EA%B5%90'
               target='_blank'
               rel='noopener noreferrer'
+              className='inline-flex items-center h-10 px-3 rounded-lg hover:bg-white/10'
             >
               띵지위키
             </a>
+          </li>
+          {/* 로그인/로그아웃: 다른 메뉴와 동일한 형식 */}
+          <li>
+            <button
+              onClick={handleAuthClick}
+              className='inline-flex items-center gap-2 h-10 px-3 rounded-lg hover:bg-white/10 transition-colors'
+              title={isLoggedIn ? '로그아웃' : '로그인'}
+            >
+              {isLoggedIn ? (
+                <>
+                  <FiLogOut size={16} className='block' />
+                  로그아웃
+                </>
+              ) : (
+                <>
+                  <FiLogIn size={16} className='block' />
+                  로그인
+                </>
+              )}
+            </button>
           </li>
         </ul>
       </div>
 
       {/* 모바일 메뉴 */}
       {isOpen && (
-        <ul className='flex flex-col md:hidden bg-[#002f6c] text-white text-sm font-medium list-none p-4 gap-3'>
+        <ul className='flex flex-col md:hidden bg-[#002f6c] text-white text-sm font-medium list-none px-4 py-2 gap-1 leading-none border-t border-white/10'>
           <li>
-            <span className='px-3 py-2 rounded cursor-default text-white/60'>학과정보</span>
+            <span className='block px-3 h-10 rounded-lg cursor-default text-white/60 flex items-center'>
+              학과정보
+            </span>
           </li>
           <li>
-            <Link to='/menu' className='px-3 py-2 block'>
+            <Link
+              to='/menu'
+              onClick={closeMenu}
+              className='block px-3 h-10 rounded-lg flex items-center hover:bg-white/10'
+            >
               식단
             </Link>
           </li>
           <li>
-            <span className='px-3 py-2 rounded cursor-default text-white/60'>벼룩시장</span>
+            <span className='block px-3 h-10 rounded-lg cursor-default text-white/60 flex items-center'>
+              벼룩시장
+            </span>
           </li>
           <li>
-            <span className='px-3 py-2 rounded cursor-default text-white/60'>제휴</span>
+            <span className='block px-3 h-10 rounded-lg cursor-default text-white/60 flex items-center'>
+              제휴
+            </span>
           </li>
           <li>
-            <Link to='/notice' className='px-3 py-2 block'>
+            <Link
+              to='/notice'
+              onClick={closeMenu}
+              className='block px-3 h-10 rounded-lg flex items-center hover:bg-white/10'
+            >
               공지사항
             </Link>
           </li>
           <li>
-            <Link to='/board' className='px-3 py-2 block'>
+            <Link
+              to='/board'
+              onClick={closeMenu}
+              className='block px-3 h-10 rounded-lg flex items-center hover:bg-white/10'
+            >
               검색게시판
             </Link>
           </li>
           <li>
-            <span className='px-3 py-2 rounded cursor-default text-white/60'>취업후기</span>
+            <span className='block px-3 h-10 rounded-lg cursor-default text-white/60 flex items-center'>
+              취업후기
+            </span>
           </li>
           <li>
             <a
               href='https://namu.wiki/w/%EB%AA%85%EC%A7%80%EB%8C%80%ED%95%99%EA%B5%90'
               target='_blank'
               rel='noopener noreferrer'
-              className='px-3 py-2 block'
+              className='block px-3 h-10 rounded-lg flex items-center hover:bg-white/10'
+              onClick={closeMenu}
             >
               띵지위키
             </a>
+          </li>
+          <li>
+            <button
+              onClick={() => {
+                handleAuthClick();
+                closeMenu();
+              }}
+              className='flex items-center gap-2 px-3 h-10 rounded-lg hover:bg-white/10 transition-colors'
+            >
+              {isLoggedIn ? (
+                <>
+                  <FiLogOut size={16} className='block' /> 로그아웃
+                </>
+              ) : (
+                <>
+                  <FiLogIn size={16} className='block' /> 로그인
+                </>
+              )}
+            </button>
           </li>
         </ul>
       )}

--- a/src/components/organisms/Navbar.tsx
+++ b/src/components/organisms/Navbar.tsx
@@ -4,7 +4,7 @@ import { HiMenu, HiX } from 'react-icons/hi';
 import { useState } from 'react';
 import { FiLogIn, FiLogOut } from 'react-icons/fi';
 import { useAuthStore } from '../../store/useAuthStore';
-
+import toast from 'react-hot-toast';
 const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
   const { isLoggedIn, logout } = useAuthStore();
@@ -17,10 +17,18 @@ const Navbar = () => {
   };
   const closeMenu = () => setIsOpen(false);
 
+  const handleBoardClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault(); //Link tag의 Default Event를 방지.
+
+    if (!isLoggedIn) {
+      toast.error('로그인이 필요한 서비스입니다.');
+      navigate('/login');
+    }
+  };
+
   return (
     <nav className='bg-[#002f6c] h-14 w-full z-50 shadow-sm overflow-hidden'>
       <div className='mx-auto md:max-w-[1200px] w-[90%] h-full px-4 flex items-center justify-between'>
-        {/* 브랜드 */}
         <Link to='/' className='h-full'>
           <div className='flex items-center h-full gap-3'>
             <img src={logo} alt='Logo' className='w-8 h-8 block' />
@@ -80,6 +88,7 @@ const Navbar = () => {
             <Link
               to='/board'
               className='inline-flex items-center h-10 px-3 rounded-lg hover:bg-white/10'
+              onClick={handleBoardClick}
             >
               검색게시판
             </Link>

--- a/src/components/organisms/Navbar.tsx
+++ b/src/components/organisms/Navbar.tsx
@@ -27,7 +27,7 @@ const Navbar = () => {
   };
 
   return (
-    <nav className='bg-[#002f6c] h-14 w-full z-50 shadow-sm overflow-hidden'>
+    <nav className='bg-mju-primary h-14 w-full z-50 shadow-sm overflow-hidden'>
       <div className='mx-auto md:max-w-[1200px] w-[90%] h-full px-4 flex items-center justify-between'>
         <Link to='/' className='h-full'>
           <div className='flex items-center h-full gap-3'>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,12 +3,13 @@ import './index.css';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-
+import { Toaster } from 'react-hot-toast';
 const queryClient = new QueryClient();
 createRoot(document.getElementById('root')!).render(
   <BrowserRouter>
     <QueryClientProvider client={queryClient}>
       <App />
+      <Toaster position='top-center' />
     </QueryClientProvider>
   </BrowserRouter>,
 );

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -3,18 +3,13 @@ import LoginForm from '../../components/organisms/LoginForm';
 const Login = () => {
   return (
     <div className='w-full  py-[30%] md:py-10 h-full bg-grey-05 md:w-[1280px] md:min-h-screen flex flex-col md:mx-auto p-12'>
-      {/* 제목: 왼쪽 정렬 */}
-
-      {/* 가운데 정렬 영역 */}
       <p className='text-2xl mb-4 md:text-4xl font-bold text-mju-primary'>로그인</p>
       <div className='w-full mx-auto flex justify-center items-center'>
         <div className='w-[375px] flex flex-col md:gap-6 md:w-[672px]'>
-          {/* 하얀 박스: 로그인 폼 */}
           <div className='flex mx-auto w-[80%] md:w-full md:min-h-[480px] items-center bg-white p-6 rounded-xl'>
             <LoginForm />
           </div>
 
-          {/* 아이디/비밀번호 찾기 */}
           <div className='w-[375px] md:w-full mt-4 flex justify-center gap-4 md:gap-20 text-sm md:text-md'>
             <p className='font-normal text-[#999999]'>아이디 찾기</p>
             <p className='font-normal text-[#999999]'>|</p>

--- a/src/pages/board/index.tsx
+++ b/src/pages/board/index.tsx
@@ -25,7 +25,7 @@ export default function Board() {
 
   useEffect(() => {
     if (!isLoggedIn) {
-      toast.error('검색게시판을 조회할 권한이 없습니다.');
+      toast.error('로그인이 필요한 서비스입니다.');
       navigate('/', { replace: true, state: { from: location.pathname } });
     }
   }, [isLoggedIn, navigate, location.pathname]);

--- a/src/pages/board/index.tsx
+++ b/src/pages/board/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import SearchBar from '../../components/atoms/SearchBar';
 import { Typography } from '../../components/atoms/Typography';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import Pagination from '../../components/molecules/common/Pagination';
 import { getBoards, type BoardItem } from '../../api/board';
 import LoadingIndicator from '../../components/atoms/LoadingIndicator';
@@ -9,6 +9,8 @@ import Divider from '../../components/atoms/Divider';
 import { IoIosChatbubbles, IoIosHeart } from 'react-icons/io';
 import { RxDividerVertical } from 'react-icons/rx';
 import { formatToElapsedTime } from '../../utils';
+import toast from 'react-hot-toast';
+import { useAuthStore } from '../../store/useAuthStore';
 
 export default function Board() {
   const [contents, setContents] = useState<BoardItem[]>([]);
@@ -17,6 +19,16 @@ export default function Board() {
   const [totalPages, setTotalPages] = useState(0);
   const initializedRef = useRef(false);
 
+  const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      toast.error('검색게시판을 조회할 권한이 없습니다.');
+      navigate('/', { replace: true, state: { from: location.pathname } });
+    }
+  }, [isLoggedIn, navigate, location.pathname]);
   /**
    * 페이지네이션 초기화
    */

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,8 @@
-import NoticeSection from '../components/organisms/sections/NoticeSection';
-import MealSection from '../components/organisms/sections/MealSection';
-import NewsSection from '../components/organisms/sections/NewsSection';
 import LayoutForMain from '../components/templates/LayoutForMain';
-import BroadcastSection from '../components/organisms/sections/BroadcastSection';
-
+import MealSection from '../components/organisms/Sections/MealSection';
+import NoticeSection from '../components/organisms/Sections/NoticeSection';
+import NewsSection from '../components/organisms/Sections/NewsSection';
+import BroadcastSection from '../components/organisms/Sections/BroadcastSection';
 const Main = () => {
   return (
     <LayoutForMain>


### PR DESCRIPTION
#67 
<img width="958" height="1000" alt="스크린샷 2025-08-11 오후 10 35 28" src="https://github.com/user-attachments/assets/65543575-4919-4c4e-bf1d-ef013d27b384" />
<img width="965" height="971" alt="스크린샷 2025-08-11 오후 10 35 34" src="https://github.com/user-attachments/assets/a90d267f-37e5-48ae-a4dc-4b074fd00dac" />
<img width="958" height="950" alt="스크린샷 2025-08-11 오후 10 35 41" src="https://github.com/user-attachments/assets/4711d694-7231-4665-887e-ed7eff36bbbc" />

1. navbar 의 전역 로그인 로직 추가
2. 검색게시판(민감정보) 로그인 상태에 따른 검열
3. 회원가입 버튼 스타일 변경 Button Type 추가 (blue20)