### PR TITLE
[Feat] 메인페이지, 명대방송 페이지 반응형 구현  + 명대방송 데이터 Fetching UX 성능 개선

### DIFF
--- a/src/components/molecules/mainpage/Tab/index.tsx
+++ b/src/components/molecules/mainpage/Tab/index.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useRef } from 'react';
 
 interface TabComponentProps {
   currentTab: string;
@@ -14,23 +15,83 @@ const tabNameMap: Record<string, string> = {
   학칙개정: 'rule',
 };
 
-const tabNameMapKeys = Object.keys(tabNameMap);
-const TabComponent = ({ currentTab, setCurrentTab }: TabComponentProps) => {
+const tabs = Object.entries(tabNameMap); // [ [label, value], ... ]
+
+export default function TabComponent({ currentTab, setCurrentTab }: TabComponentProps) {
+  const scrollerRef = useRef<HTMLDivElement>(null);
+
   return (
-    <div className='flex flex-row justify-center gap-16 border-b  border-grey-20 pb-2'>
-      {tabNameMapKeys.map((tab) => (
-        <button
-          key={tab}
-          onClick={() => setCurrentTab(tabNameMap[tab])}
-          className={`text-l pb-1 font-medium transition-colors duration-200
-            ${currentTab === tabNameMap[tab] ? 'text-l font-medium text-blue-20 border-b-2 border-blue-20' : 'text-grey-20'}
-          `}
+    <div className='border-b border-grey-20 pb-2'>
+      {/* 데스크톱: 라인 탭 */}
+      <div className='hidden md:flex justify-center gap-18'>
+        {tabs.map(([label, value]) => {
+          const active = currentTab === value;
+          return (
+            <button
+              key={value}
+              role='tab'
+              aria-selected={active}
+              aria-controls={`tab-panel-${value}`}
+              onClick={() => setCurrentTab(value)}
+              className={`
+                relative pb-2 text-base transition-colors
+                ${active ? 'text-blue-20 font-semibold' : 'text-grey-20 hover:text-grey-40'}
+              `}
+            >
+              {label}
+              <span
+                className={`
+                  absolute left-0 right-0 -bottom-[2px] h-[2px]
+                  transition-all duration-200
+                  ${active ? 'bg-mju-primary' : 'bg-transparent'}
+                `}
+              />
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 모바일: 캐러셀 탭 (필 스타일 + 센터 스냅) */}
+      <div className='md:hidden relative'>
+        {/* 캐러셀 스크롤 영역 */}
+        <div
+          ref={scrollerRef}
+          role='tablist'
+          aria-label='공지 탭'
+          className='
+            no-scrollbar
+            -mx-4 px-10  /* 버튼 영역 여백 확보 */
+            overflow-x-auto scroll-smooth
+            snap-x snap-mandatory whitespace-nowrap
+            flex gap-3 py-1
+          '
         >
-          {tab}
-        </button>
-      ))}
+          {tabs.map(([label, value]) => {
+            const active = currentTab === value;
+            return (
+              <button
+                key={value}
+                role='tab'
+                aria-selected={active}
+                aria-controls={`tab-panel-${value}`}
+                onClick={() => setCurrentTab(value)}
+                className={`
+                  snap-center shrink-0
+                  px-4 py-2 rounded-full text-sm
+                  border transition-all
+                  ${
+                    active
+                      ? 'bg-mju-primary text-white border-blue-20 shadow-sm'
+                      : 'bg-white text-gray-700 border-gray-200 hover:bg-gray-50'
+                  }
+                `}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
     </div>
   );
-};
-
-export default TabComponent;
+}

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -4,9 +4,12 @@ export default function Header() {
   return (
     <div className='w-full bg-white'>
       <div className='max-w-screen-xl mx-auto px-4 py-4'>
-        <div className='flex items-center gap-3 text-[1.1rem] font-semibold text-[#0055ff]'>
-          <FaBullhorn className='text-[1.4rem]' />
-          <span>현재 Version1 작업중입니다 _ MJS 일동</span>
+        <div className='hidden'>
+          <div className='flex items-center gap-3 text-[1.1rem] font-semibold text-[#0055ff]'>
+            <FaBullhorn className='text-[1.4rem]' />
+
+            <span>현재 Version1 작업중입니다 _ MJS 일동</span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -4,12 +4,10 @@ export default function Header() {
   return (
     <div className='w-full bg-white'>
       <div className='max-w-screen-xl mx-auto px-4 py-4'>
-        <div className='hidden'>
-          <div className='flex items-center gap-3 text-[1.1rem] font-semibold text-[#0055ff]'>
-            <FaBullhorn className='text-[1.4rem]' />
+        <div className='flex items-center  gap-3 text-[1.1rem] font-semibold text-[#0055ff]'>
+          <FaBullhorn className='text-[1.4rem]' />
 
-            <span>현재 Version1 작업중입니다 _ MJS 일동</span>
-          </div>
+          <span>현재 Version1 작업중입니다 _ MJS 일동</span>
         </div>
       </div>
     </div>

--- a/src/components/organisms/Navbar.tsx
+++ b/src/components/organisms/Navbar.tsx
@@ -18,16 +18,15 @@ const Navbar = () => {
   const closeMenu = () => setIsOpen(false);
 
   const handleBoardClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault(); //Link tag의 Default Event를 방지.
-
     if (!isLoggedIn) {
+      e.preventDefault(); //Link tag의 Default Event를 방지.
       toast.error('로그인이 필요한 서비스입니다.');
       navigate('/login');
     }
   };
 
   return (
-    <nav className='bg-mju-primary h-14 w-full z-50 shadow-sm overflow-hidden'>
+    <nav className={`bg-mju-primary w-full z-50 shadow-sm ${isOpen ? 'h-auto' : 'h-14'}`}>
       <div className='mx-auto md:max-w-[1200px] w-[90%] h-full px-4 flex items-center justify-between'>
         <Link to='/' className='h-full'>
           <div className='flex items-center h-full gap-3'>

--- a/src/components/organisms/Navbar.tsx
+++ b/src/components/organisms/Navbar.tsx
@@ -4,6 +4,7 @@ import { HiMenu, HiX } from 'react-icons/hi';
 import { useState } from 'react';
 import { FiLogIn, FiLogOut } from 'react-icons/fi';
 import { useAuthStore } from '../../store/useAuthStore';
+import { useEffect } from 'react';
 import toast from 'react-hot-toast';
 const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -25,8 +26,14 @@ const Navbar = () => {
     }
   };
 
+  useEffect(() => {
+    const root = document.documentElement;
+    if (isOpen) root.classList.add('overflow-hidden');
+    else root.classList.remove('overflow-hidden');
+    return () => root.classList.remove('overflow-hidden');
+  }, [isOpen]);
   return (
-    <nav className={`bg-mju-primary w-full z-50 shadow-sm ${isOpen ? 'h-auto' : 'h-14'}`}>
+    <nav className={`bg-mju-primary w-full  z-50 shadow-sm ${isOpen ? 'h-auto' : 'h-14'}`}>
       <div className='mx-auto md:max-w-[1200px] w-[90%] h-full px-4 flex items-center justify-between'>
         <Link to='/' className='h-full'>
           <div className='flex items-center h-full gap-3'>

--- a/src/components/templates/LayoutForMain.tsx
+++ b/src/components/templates/LayoutForMain.tsx
@@ -29,14 +29,21 @@ const LayoutForMain = ({ children }: LayoutProps) => {
 
           <div className='min-w-0 w-full md:w-2/3 flex flex-col gap-3'>
             <SearchBar />
+            <div className='md:hidden'>
+              <ProfileComponent />
+            </div>
+
             {children}
           </div>
 
           {/* 우 컬럼: 프로필 + 날씨 */}
-          {/* ✅ 모바일에서도 세로 스택. 줄바꿈 허용을 위해 min-w-0 */}
           <div className='min-w-0 w-full md:w-1/3 flex flex-col gap-3'>
-            <ProfileComponent />
-            <WeatherComponent />
+            <div className='hidden'>
+              <ProfileComponent />
+            </div>
+            <div className='hidden'>
+              <WeatherComponent />
+            </div>
           </div>
         </div>
       </main>

--- a/src/components/templates/LayoutForMain.tsx
+++ b/src/components/templates/LayoutForMain.tsx
@@ -7,33 +7,40 @@ import SearchBar from '../atoms/SearchBar';
 import ProfileComponent from '../organisms/ProfileComponent';
 import WeatherComponent from '../molecules/mainpage/Weather';
 import type { ReactNode } from 'react';
+
 interface LayoutProps {
   children: ReactNode;
 }
+
 const LayoutForMain = ({ children }: LayoutProps) => {
   const location = useLocation();
   const hideHeaderRoutes = ['/login', '/register', '/notice', '/news'];
   const shouldShowHeader = !hideHeaderRoutes.includes(location.pathname);
 
   return (
-    <div className='flex flex-col w-screen min-h-screen items-center'>
+    <div className='flex flex-col w-screen min-h-screen'>
       <Navbar />
 
-      <main className='flex-1 w-[1280px] mx-auto flex flex-col'>
+      <main className='flex-1 w-full max-w-[1280px] mx-auto flex flex-col px-4 md:px-0'>
         {shouldShowHeader && <Header />}
 
         <div className='flex flex-col md:flex-row gap-4 mt-6'>
-          <div className='w-full md:w-2/3 flex flex-col gap-3'>
+          {/* 좌 컬럼: 검색 + 메인 콘텐츠 */}
+
+          <div className='min-w-0 w-full md:w-2/3 flex flex-col gap-3'>
             <SearchBar />
             {children}
           </div>
 
-          <div className='w-full md:w-1/3 flex flex-col gap-3'>
+          {/* 우 컬럼: 프로필 + 날씨 */}
+          {/* ✅ 모바일에서도 세로 스택. 줄바꿈 허용을 위해 min-w-0 */}
+          <div className='min-w-0 w-full md:w-1/3 flex flex-col gap-3'>
             <ProfileComponent />
             <WeatherComponent />
           </div>
         </div>
       </main>
+
       <Footer />
     </div>
   );

--- a/src/components/templates/LayoutForMain.tsx
+++ b/src/components/templates/LayoutForMain.tsx
@@ -22,7 +22,7 @@ const LayoutForMain = ({ children }: LayoutProps) => {
       <Navbar />
 
       <main className='flex-1 w-full max-w-[1280px] mx-auto flex flex-col px-4 md:px-0'>
-        {shouldShowHeader && <Header />}
+        <div className='hidden md:block'>{shouldShowHeader && <Header />}</div>
 
         <div className='flex flex-col md:flex-row gap-4 mt-6'>
           {/* 좌 컬럼: 검색 + 메인 콘텐츠 */}

--- a/src/pages/broadcast/index.tsx
+++ b/src/pages/broadcast/index.tsx
@@ -3,22 +3,24 @@ import { useEffect, useState } from 'react';
 import { fetchBroadCastInfo } from '../../api/main/broadcast-api';
 import type { BroadcastContent } from '../../types/broadcast/broadcastInfo';
 import Pagination from '../../components/molecules/pagination';
+
 const extractYoutubeId = (url: string): string => {
   let match = url.match(/v=([^&]+)/);
   if (match) return match[1];
-
   match = url.match(/youtu\.be\/([^?]+)/);
   if (match) return match[1];
-
   return '';
 };
 
 const formatDate = (isoDate: string): string => {
   const date = new Date(isoDate);
-  return `${date.getFullYear()}.${(date.getMonth() + 1)
+  return `${date.getFullYear()}.${(date.getMonth() + 1).toString().padStart(2, '0')}.${date
+    .getDate()
     .toString()
-    .padStart(2, '0')}.${date.getDate().toString().padStart(2, '0')}`;
+    .padStart(2, '0')}`;
 };
+
+const PAGE_SIZE = 9;
 
 const Broadcast = () => {
   const { id } = useParams<{ id: string }>();
@@ -26,25 +28,22 @@ const Broadcast = () => {
   const [totalPage, setTotalPage] = useState(0);
   const [currentPage, setCurrentPage] = useState(0);
   const [loading, setLoading] = useState(true);
-
-  const PAGE_SIZE = 9;
+  const [playingId, setPlayingId] = useState<string | null>(null); // ✅ 클릭 시 해당 카드만 임베드
 
   useEffect(() => {
     const loadBroadcast = async () => {
       try {
-        const broadcastInfo = await fetchBroadCastInfo(currentPage, PAGE_SIZE); // 모든 데이터 중 id로 찾음
-        const fetchedTotalPages = broadcastInfo.data.totalPages;
-
-        setTotalPage(fetchedTotalPages);
-
-        setBroadcast(broadcastInfo.data.content);
+        setLoading(true);
+        const res = await fetchBroadCastInfo(currentPage, PAGE_SIZE);
+        setTotalPage(res.data.totalPages);
+        setBroadcast(res.data.content);
+        setPlayingId(null); // 페이지 바뀌면 재생 초기화
       } catch (err) {
         console.error('방송 데이터를 불러오는 데 실패했습니다.', err);
       } finally {
         setLoading(false);
       }
     };
-
     loadBroadcast();
   }, [id, currentPage]);
 
@@ -52,40 +51,82 @@ const Broadcast = () => {
     return <div className='p-6 text-gray-500 text-sm'>로딩 중...</div>;
   }
 
-  if (!broadcast) {
+  if (!broadcast || broadcast.length === 0) {
     return <div className='p-6 text-red-500 text-sm'>해당 방송을 찾을 수 없습니다.</div>;
   }
 
   return (
-    <div className=' w-[1280px] min-h-screen flex flex-col mx-auto p-12'>
-      <p className='text-4xl font-bold text-mju-primary'>명대방송</p>
-      <main className='max-w-5xl mx-auto px-6 py-12'>
-        <section className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6'>
+    <div className='w-full max-w-[1280px] min-h-screen flex flex-col mx-auto px-4 md:px-6 py-8'>
+      <p className='text-2xl md:text-4xl font-bold text-mju-primary'>명대방송</p>
+
+      <main className='mx-auto w-full'>
+        <section className='grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3  gap-3 md:gap-6 mt-6'>
           {broadcast.map((item) => {
             const vid = extractYoutubeId(item.url);
+            const key = vid || item.url;
+            const isPlaying = playingId === vid;
+
             return (
-              <article key={vid} className='border rounded-md overflow-hidden'>
-                <iframe
-                  className='w-full aspect-video'
-                  src={`https://www.youtube.com/embed/${vid}`}
-                  title={item.title}
-                  allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture'
-                  allowFullScreen
-                />
+              <article
+                key={key}
+                className='border rounded-md overflow-hidden bg-white shadow-sm hover:shadow transition-shadow'
+              >
+                <div className='w-full aspect-video relative'>
+                  {isPlaying && vid ? (
+                    <iframe
+                      className='absolute inset-0 w-full h-full'
+                      src={`https://www.youtube.com/embed/${vid}?autoplay=1`}
+                      title={item.title}
+                      allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture'
+                      allowFullScreen
+                      loading='lazy'
+                    />
+                  ) : (
+                    <button
+                      type='button'
+                      aria-label={`${item.title} 재생`}
+                      onClick={() => vid && setPlayingId(vid)}
+                      className='absolute inset-0 w-full h-full'
+                    >
+                      <img
+                        src={vid ? `https://img.youtube.com/vi/${vid}/hqdefault.jpg` : ''}
+                        alt={item.title}
+                        className='w-full h-full object-cover'
+                        loading='lazy'
+                      />
+                      {/* 플레이 버튼 오버레이 */}
+                      <span className='absolute inset-0 grid place-items-center'>
+                        <span className='h-14 w-14 rounded-full bg-black/60 grid place-items-center'>
+                          <svg
+                            width='22'
+                            height='22'
+                            viewBox='0 0 24 24'
+                            fill='white'
+                            aria-hidden='true'
+                          >
+                            <path d='M8 5v14l11-7z' />
+                          </svg>
+                        </span>
+                      </span>
+                    </button>
+                  )}
+                </div>
+
                 <div className='p-3'>
-                  <h2 className='text-sm font-semibold line-clamp-2'>{item.title}</h2>
-                  <p className='text-xs text-gray-500'>{formatDate(item.publishedAt)}</p>
+                  <h2 className='text-sm md:text-base font-semibold line-clamp-2'>{item.title}</h2>
+                  <p className='mt-1 text-xs text-gray-500'>{formatDate(item.publishedAt)}</p>
                 </div>
               </article>
             );
           })}
         </section>
-        <div className='mt-6'>
+
+        <div className='mt-4 md:mt-6'>
           <Pagination
             currentPage={currentPage}
             totalPages={totalPage}
             onChange={(p) => setCurrentPage(p)}
-            window={10} // 가운데 점의 갯수.
+            window={6} // 모바일에서 더 컴팩트하게
           />
         </div>
       </main>


### PR DESCRIPTION
#73 
<img width="1113" height="983" alt="스크린샷 2025-08-14 오후 10 31 35" src="https://github.com/user-attachments/assets/a49f2419-96fd-46b2-8358-2f5dd3e771e4" />
<img width="1130" height="1030" alt="스크린샷 2025-08-14 오후 10 32 08" src="https://github.com/user-attachments/assets/3fbf3bea-a3ab-4b91-be06-1f1b9a037713" />

<img width="1911" height="999" alt="스크린샷 2025-08-14 오후 10 32 35" src="https://github.com/user-attachments/assets/50d132cb-c930-45e1-a278-74b10167684c" />

1. 메인페이지 모바일 시의 반응형 구현 (오른쪽 컴포넌트 라인들을 왼쪽으로 조작해 옮겨 한 라인으로)
2. 공지사항 tabComponent -> 캐러셀 + xy 스크롤 구현
3. 날씨 컴포넌트 메인에서 제거 (mobile 환경)
4. 기존 방송국관련 데이터 받아올때 체감상 속도가 1초 정도 걸려 사용자 경험상 좋지 않은 문제를 해결했습니다.
해결한 가이드라인 곧 포스팅해서 올리겠습니다.