### PR TITLE
[Feat] 명대뉴스 상세 페이지 및 학식 상세 페이지 반응형 구현

### DIFF
--- a/src/components/molecules/mainpage/Meal/index.tsx
+++ b/src/components/molecules/mainpage/Meal/index.tsx
@@ -15,6 +15,7 @@ const MealComponent = ({ title, items, highlight }: MealComponentProps) => {
         >
           {title}
         </h2>
+        \{' '}
       </div>
       <ul className='px-4 py-2 text-sm text-black-40 space-y-1'>
         {items.map((item, idx) => (

--- a/src/components/organisms/Navbar.tsx
+++ b/src/components/organisms/Navbar.tsx
@@ -21,7 +21,12 @@ const Navbar = () => {
   const handleBoardClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     if (!isLoggedIn) {
       e.preventDefault(); //Link tag의 Default Event를 방지.
-      toast.error('로그인이 필요한 서비스입니다.');
+
+      toast.error('로그인이 필요한 서비스입니다.', {
+        autoClose: 2000, // 2초 후 자동 닫힘
+        pauseOnHover: true,
+        onClose: () => navigate('/login'), // 닫힌 뒤 이동
+      });
       navigate('/login');
     }
   };

--- a/src/components/organisms/WeeklyMenuTable/index.tsx
+++ b/src/components/organisms/WeeklyMenuTable/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import type { MenuItem } from '../../../api/menu';
 import MenuDayButton from '../../molecules/MenuDayButton';
 import MenuItemButton from '../../molecules/MenuItemButton';
@@ -9,24 +9,69 @@ const timeLabelMap = {
   DINNER: '저녁',
 } as const;
 
-export default function WeeklyMenuTable({ menus }: { menus: MenuItem[] }) {
-  const days = menus.reduce<MenuItem[][]>((groups, item) => {
-    if (groups.length === 0 || groups[groups.length - 1].length === 3) {
-      groups.push([item]);
-    } else {
-      groups[groups.length - 1].push(item);
-    }
-    return groups;
-  }, []);
+const ORDER: Array<keyof typeof timeLabelMap> = ['BREAKFAST', 'LUNCH', 'DINNER'];
 
-  /**
-   * 오늘 날짜 계산
-   */
+// NEW: 유틸 - 주차/주간 범위 계산 (월요일 시작)
+function startOfWeek(d: Date, weekStartsOn = 1) {
+  const date = new Date(d);
+  const day = date.getDay(); // 0=Sun ... 6=Sat
+  // 월요일 시작 기준으로 오프셋 계산
+  const diff = (day - weekStartsOn + 7) % 7;
+  date.setDate(date.getDate() - diff);
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
+function endOfWeek(d: Date, weekStartsOn = 1) {
+  const start = startOfWeek(d, weekStartsOn);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 6);
+  end.setHours(23, 59, 59, 999);
+  return end;
+}
+
+function getWeekOfMonth(d: Date, weekStartsOn = 1) {
+  const date = new Date(d);
+  const month = date.getMonth(); // 0-11
+  const firstOfMonth = new Date(date.getFullYear(), month, 1);
+  const firstWeekStart = startOfWeek(firstOfMonth, weekStartsOn);
+  const thisWeekStart = startOfWeek(date, weekStartsOn);
+  // 주차 = (해당 주의 월요일과 월 1일이 포함된 첫 주의 월요일 간 일수 차이)/7 + 1
+  const diffDays = Math.floor(
+    (thisWeekStart.getTime() - firstWeekStart.getTime()) / (1000 * 60 * 60 * 24),
+  );
+  return Math.floor(diffDays / 7) + 1;
+}
+
+function fmtMD(date: Date) {
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${m}.${d}`;
+}
+
+export default function WeeklyMenuTable({ menus }: { menus: MenuItem[] }) {
+  const groupedByDate = useMemo(() => {
+    const map = new Map<string, MenuItem[]>();
+    for (const item of menus) {
+      if (!map.has(item.date)) map.set(item.date, []);
+      map.get(item.date)!.push(item);
+    }
+    for (const [, arr] of map.entries()) {
+      arr.sort(
+        (a, b) =>
+          ORDER.indexOf(a.menuCategory as keyof typeof timeLabelMap) -
+          ORDER.indexOf(b.menuCategory as keyof typeof timeLabelMap),
+      );
+    }
+    return Array.from(map.entries()).sort(([d1], [d2]) => d1.localeCompare(d2));
+  }, [menus]); // PERF: O(N) 변환 + 정렬 한 번만
+
+  // 오늘/현재 끼니 계산
   const now = new Date();
   const mm = String(now.getMonth() + 1).padStart(2, '0');
   const dd = String(now.getDate()).padStart(2, '0');
   const dow = ['일', '월', '화', '수', '목', '금', '토'][now.getDay()];
-  const todayDate = `${mm}.${dd} (${dow})`; // API의 date 필드 형식에 맞춤
+  const todayDate = `${mm}.${dd} (${dow})`; // API date 포맷 가정
   const hour = now.getHours() + now.getMinutes() / 60;
   const nowCategory =
     hour >= 6 && hour < 9
@@ -37,29 +82,125 @@ export default function WeeklyMenuTable({ menus }: { menus: MenuItem[] }) {
           ? 'DINNER'
           : undefined;
 
-  return (
-    <div className='grid grid-cols-[80px_repeat(3,1fr)] gap-6'>
-      {days.map((dayItems) => {
-        const date = dayItems[0].date; // ex) "07.14 (월)"
+  // NEW: "8월 N주차" + "주간 기간" 계산 (월요일~일요일)
+  const weekStartsOn = 1; // 월요일
+  const weekStart = startOfWeek(now, weekStartsOn);
+  const weekEnd = endOfWeek(now, weekStartsOn);
+  const weekOfMonth = getWeekOfMonth(now, weekStartsOn);
+  const monthLabel = now.getMonth() + 1;
+  const weekRangeLabel = `${fmtMD(weekStart)} ~ ${fmtMD(weekEnd)}`;
+
+  // --- 주차 헤더 (공통 상단) ---
+  // NEW: 데스크톱/모바일 모두 위에 노출되는 주차 헤더
+  const WeekHeader = () => (
+    <div className='mb-3 md:mb-4 flex items-baseline justify-between'>
+      <h3 className='text-base md:text-lg font-semibold text-mju-primary'>
+        {/* 예: 8월 3주차 */}
+        {monthLabel}월 {weekOfMonth}주차
+      </h3>
+      <span className='text-xs md:text-sm text-gray-500'>{weekRangeLabel}</span>
+    </div>
+  );
+
+  // --- 데스크톱(≥md): 테이블 레이아웃 ---
+  const DesktopTable = () => (
+    <div className='hidden md:grid grid-cols-[88px_repeat(3,minmax(0,1fr))] gap-3'>
+      <div className='sticky left-0 z-10 bg-white/80 backdrop-blur-md font-semibold text-sm px-2 py-1 rounded'>
+        요일
+      </div>
+      {ORDER.map((k) => (
+        <div key={k} className='font-semibold text-sm px-2 py-1'>
+          {timeLabelMap[k]}
+        </div>
+      ))}
+
+      {groupedByDate.map(([date, dayItems]) => {
         const isToday = date === todayDate;
+        const weekdayLabel = `${date.split('(')[1]?.split(')')[0]?.trim() ?? ''}요일`;
+
+        const fullRow = ORDER.map((k) => dayItems.find((d) => d.menuCategory === k));
 
         return (
           <React.Fragment key={date}>
-            <MenuDayButton
-              label={`${date.split('(')[1]?.split(')')[0]?.trim() ?? ''}요일`}
-              focused={isToday}
-            />
-            {dayItems.map((item) => (
-              <MenuItemButton
-                key={item.menuCategory}
-                time={timeLabelMap[item.menuCategory]}
-                menus={item.meals}
-                focused={isToday && item.menuCategory === nowCategory}
-              />
-            ))}
+            <div className='sticky left-0 z-10 bg-white/80 backdrop-blur-md px-0 py-0'>
+              <MenuDayButton label={weekdayLabel} focused={isToday} aria-current={isToday} />
+            </div>
+
+            {fullRow.map((item, idx) =>
+              item ? (
+                <MenuItemButton
+                  key={item.menuCategory}
+                  time={timeLabelMap[item.menuCategory as keyof typeof timeLabelMap]}
+                  menus={item.meals}
+                  focused={isToday && item.menuCategory === nowCategory}
+                  aria-current={isToday && item.menuCategory === nowCategory}
+                />
+              ) : (
+                <div
+                  key={`empty-${date}-${idx}`}
+                  className='min-h-16 rounded-xl border border-dashed text-xs text-gray-400 flex items-center justify-center'
+                >
+                  등록된 메뉴가 없어요
+                </div>
+              ),
+            )}
           </React.Fragment>
         );
       })}
+    </div>
+  );
+
+  const MobileCards = () => (
+    <div className='md:hidden flex flex-col gap-4'>
+      {groupedByDate.map(([date, dayItems]) => {
+        const isToday = date === todayDate;
+        const weekdayLabel = `${date.split('(')[1]?.split(')')[0]?.trim() ?? ''}요일`;
+        const fullRow = ORDER.map((k) => dayItems.find((d) => d.menuCategory === k));
+
+        return (
+          <section
+            key={date}
+            className={`rounded-2xl border shadow-sm ${
+              isToday ? 'border-mju-primary/60' : 'border-gray-200'
+            }`}
+          >
+            <div className='flex items-center justify-between px-3 py-2 border-b bg-white/60 backdrop-blur-sm rounded-t-2xl'>
+              <MenuDayButton label={weekdayLabel} focused={isToday} aria-current={isToday} />
+              <span className='text-xs text-gray-500'>{date}</span>
+            </div>
+
+            <div className='grid grid-cols-1 gap-2 p-3'>
+              {fullRow.map((item, idx) =>
+                item ? (
+                  <MenuItemButton
+                    key={item.menuCategory}
+                    time={timeLabelMap[item.menuCategory as keyof typeof timeLabelMap]}
+                    menus={item.meals}
+                    focused={isToday && item.menuCategory === nowCategory}
+                    aria-current={isToday && item.menuCategory === nowCategory}
+                  />
+                ) : (
+                  <div
+                    key={`empty-mobile-${date}-${idx}`}
+                    className='min-h-14 rounded-xl border border-dashed text-xs text-gray-400 flex items-center justify-center'
+                  >
+                    메뉴 없음
+                  </div>
+                ),
+              )}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+
+  return (
+    <div className='w-full'>
+      {/* NEW: 주차 헤더 */}
+      <WeekHeader />
+      <DesktopTable />
+      <MobileCards />
     </div>
   );
 }

--- a/src/pages/menu/index.tsx
+++ b/src/pages/menu/index.tsx
@@ -4,13 +4,11 @@ import { Typography } from '../../components/atoms/Typography';
 import WeeklyMenuTable from '../../components/organisms/WeeklyMenuTable';
 import { getMenus } from '../../api/menu';
 import type { MenuItem } from '../../api/menu';
+import toast from 'react-hot-toast';
 
 export default function Menu() {
   const [contents, setContents] = useState<MenuItem[]>([]);
 
-  /**
-   * 오늘 날짜를 표시합니다
-   */
   const todayString = useMemo(() => {
     const today = new Date();
     const month = today.getMonth() + 1;
@@ -18,31 +16,31 @@ export default function Menu() {
     return `${month}월 ${day}일`;
   }, []);
 
-  /**
-   * 식단 정보를 서버에서 불러옵니다
-   */
   useEffect(() => {
-    const getData = async () => {
+    const getMealData = async () => {
       try {
-        const res = await getMenus();
-        setContents(res.data);
+        const response = await getMenus();
+        setContents(response.data);
       } catch (e) {
-        console.error(e);
+        toast.error('식단을 불러오는 중 오류가 발생했습니다!', e);
       }
     };
-    getData();
+    getMealData();
   }, []);
 
   return (
-    <div className='flex flex-col px-7 py-12 gap-12'>
-      <Typography variant='heading01' className='text-mju-primary'>
-        학식
-      </Typography>
-      <Divider />
-      <Typography variant='heading02' className='text-center text-mju-primary'>
-        {todayString}
-      </Typography>
-      <WeeklyMenuTable menus={contents} />
+    <div className='px-4 py-8 md:px-7 md:py-12'>
+      <div className='mx-auto w-full max-w-[1200px] flex flex-col gap-8 md:gap-12'>
+        <Typography variant='heading01' className='text-mju-primary'>
+          학식
+        </Typography>
+        <Divider />
+        <Typography variant='heading02' className='text-center text-mju-primary'>
+          {todayString}
+        </Typography>
+
+        <WeeklyMenuTable menus={contents} />
+      </div>
     </div>
   );
 }

--- a/src/pages/news/NewsCard.tsx
+++ b/src/pages/news/NewsCard.tsx
@@ -1,0 +1,54 @@
+import type { NewsInfo } from '../../types/news/newsInfo';
+import { memo } from 'react';
+interface NewsCardProps {
+  news: NewsInfo;
+  index: number;
+  page: number;
+  fallbackSrc?: string;
+}
+const ITEMS_PER_PAGE = 8; // 한 페이지에 8개가 적당.
+
+function NewsCard({ news, index, page, fallbackSrc = '/default-thumbnail.png' }: NewsCardProps) {
+  const id = (page - 1) * ITEMS_PER_PAGE + index + 1;
+
+  return (
+    <article
+      className='group relative flex flex-col overflow-hidden rounded-2xl border-grey-20 bg-white shadow-sm transition hover:shadow-lg'
+      aria-labelledby={`news-${id}-title`}
+    >
+      <a href={news.link} target='_blank' rel='noopener noreferrer' className='block'>
+        <div className='aspect-[16/9] w-full overflow-hidden bg-gray-100'>
+          <img
+            src={news.imageUrl?.trim() || fallbackSrc}
+            onError={(e) => {
+              (e.currentTarget as HTMLImageElement).src = fallbackSrc;
+            }}
+            alt={news.title}
+            className='h-full w-full object-cover transition duration-300 group-hover:scale-[1.02]'
+            loading='lazy'
+            sizes='(min-width:1280px) 25vw, (min-width:1024px) 33vw, (min-width:768px) 50vw, 100vw'
+          />
+        </div>
+
+        <div className='flex flex-col gap-2 p-4 md:p-5'>
+          <div className='flex items-center gap-2 text-xs md:text-[13px]'>
+            <span className='inline-flex items-center rounded-full px-2 py-0.5 font-medium text-gray-600'>
+              {news.category}
+            </span>
+            <time className='text-gray-500'>{news.date}</time>
+          </div>
+
+          <h3
+            id={`news-${id}-title`}
+            className='line-clamp-2 text-base font-semibold leading-snug md:text-lg'
+          >
+            {news.title}
+          </h3>
+
+          <p className='line-clamp-2 text-sm text-grey-40 md:line-clamp-3'>{news.summary}</p>
+        </div>
+      </a>
+    </article>
+  );
+}
+export default memo(NewsCard);

--- a/src/pages/news/SkeletonCard.tsx
+++ b/src/pages/news/SkeletonCard.tsx
@@ -1,0 +1,15 @@
+function SkeletonCard() {
+  return (
+    <div className='animate-pulse overflow-hidden rounded-2xl border bg-white'>
+      <div className='aspect-[16/9] w-full bg-gray-200' />
+      <div className='space-y-3 p-4 md:p-5'>
+        <div className='h-4 w-24 rounded bg-gray-200' />
+        <div className='h-5 w-11/12 rounded bg-gray-200' />
+        <div className='h-5 w-9/12 rounded bg-gray-200' />
+        <div className='h-4 w-10/12 rounded bg-gray-200' />
+      </div>
+    </div>
+  );
+}
+
+export default SkeletonCard;

--- a/src/pages/news/index.tsx
+++ b/src/pages/news/index.tsx
@@ -9,7 +9,7 @@ import NewsCard from './NewsCard';
 import SkeletonCard from './SkeletonCard';
 const ITEMS_PER_PAGE = 8;
 
-const News: React.FC = () => {
+const News = () => {
   const [page, setPage] = useState(1);
   const [selectedCategory, setSelectedCategory] = useState('전체');
   const [newsList, setNewsList] = useState<NewsInfo[]>([]);

--- a/src/pages/news/index.tsx
+++ b/src/pages/news/index.tsx
@@ -4,9 +4,9 @@ import Pagination from '../../components/molecules/common/Pagination';
 import CategoryFilter from '../../components/molecules/common/CategoryFilter';
 import { NewsCategory } from '../../constants/news';
 import { fetchNewsInfo } from '../../api/news';
-import NewsList from '../../components/organisms/CommonList';
 import type { NewsInfo } from '../../types/news/newsInfo';
-
+import NewsCard from './NewsCard';
+import SkeletonCard from './SkeletonCard';
 const ITEMS_PER_PAGE = 8;
 
 const News: React.FC = () => {
@@ -32,43 +32,61 @@ const News: React.FC = () => {
 
   useEffect(() => {
     loadNews();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedCategory, page]);
 
   return (
-    <div className='w-[1280px] min-h-screen flex flex-col p-12 gap-6 mx-auto'>
-      <p className='text-4xl font-bold text-mju-primary'>명대신문</p>
-      <SearchBar />
-      <CategoryFilter
-        categories={Object.keys(NewsCategory)}
-        current={selectedCategory}
-        onChange={(category) => {
-          setSelectedCategory(category);
-          setPage(1);
-        }}
-      />
+    <div className='mx-auto w-full max-w-[1280px] min-h-screen px-4 pb-16 pt-6 md:px-6 lg:px-8 lg:pt-10'>
+      <header className='mb-4 flex flex-col gap-3 md:mb-6 md:flex-row md:items-end md:justify-between'>
+        <h1 className='text-2xl font-extrabold tracking-tight text-mju-primary md:text-3xl lg:text-4xl'>
+          명대신문
+        </h1>
+        <div className='md:w-1/2 lg:w-2/5'>
+          <SearchBar />
+        </div>
+      </header>
+
+      <div className='sticky top-0 z-10 -mx-4 mb-4 border-grey-10 bg-white/80 px-4 py-2 backdrop-blur md:static md:z-auto md:mx-0 md:mb-6 md:border-0 md:bg-transparent md:p-0 md:backdrop-blur-0'>
+        <div className='no-scrollbar -mx-2 overflow-x-auto px-2 md:overflow-visible'>
+          <CategoryFilter
+            categories={Object.keys(NewsCategory)}
+            current={selectedCategory}
+            onChange={(category) => {
+              setSelectedCategory(category);
+              setPage(1);
+            }}
+          />
+        </div>
+      </div>
+
+      {/* 그리드 영역 */}
       {loading ? (
-        <p className='text-center mt-20'>로딩 중...</p>
+        <section
+          aria-label='뉴스 로딩 중'
+          className='grid grid-cols-1 gap-4 md:gap-6
+                     md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'
+        >
+          {Array.from({ length: ITEMS_PER_PAGE }).map((_, i) => (
+            <SkeletonCard key={i} />
+          ))}
+        </section>
+      ) : newsList.length === 0 ? (
+        <p className='py-24 text-center text-gray-500'>표시할 뉴스가 없습니다.</p>
       ) : (
-        <NewsList
-          items={newsList.map((news, index) => ({
-            id: (page - 1) * ITEMS_PER_PAGE + index + 1,
-            category: news.category,
-            title: news.title,
-            content: news.summary,
-            date: news.date,
-            link: news.link,
-            imgSrc: news.imageUrl?.trim() || '/default-thumbnail.png',
-            variant: 'news',
-            onError: (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
-              e.currentTarget.src = '/default-thumbnail.png';
-            },
-          }))}
-          category='news'
-          page={page}
-          itemsPerPage={ITEMS_PER_PAGE}
-        />
+        <section
+          aria-label='뉴스 목록'
+          className='grid grid-cols-1 gap-4 md:gap-6
+                     md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'
+        >
+          {newsList.map((news, idx) => (
+            <NewsCard key={news.link ?? idx} news={news} index={idx} page={page} />
+          ))}
+        </section>
       )}
-      <Pagination page={page} totalPages={totalPages} onChange={setPage} />
+
+      <div className='mt-8 flex justify-center md:mt-10'>
+        <Pagination page={page} totalPages={totalPages} onChange={setPage} />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
<img width="703" height="1011" alt="스크린샷 2025-08-16 오후 7 29 56" src="https://github.com/user-attachments/assets/bc538756-6edd-46bf-88be-30ee7bfcd998" />
<img width="712" height="1016" alt="스크린샷 2025-08-16 오후 7 30 17" src="https://github.com/user-attachments/assets/b878290d-90d4-454a-aa70-c831def88a7f" />

1. 명대신문은 서버에서 fetching 할때 약간 딜레이가 생겨서,
메모이제이션 기능 추가한 점 참고바랍니다.
2. 학식 페이지는 1주차 단위이기에, 그 해당 달의 몇 주차인지 기입해놨습니다.

