### PR TITLE
<Refactor> 메인페이지 관련 버그 및 2차 QA 리펙토링.

### DIFF
--- a/src/api/main/real-time.ts
+++ b/src/api/main/real-time.ts
@@ -1,0 +1,20 @@
+import apiClient from '../apiClient';
+
+export type RealtimeKeyword = string;
+export interface TopKeywordsResponse {
+  status: string;
+  data: RealtimeKeyword[];
+  timestamp: string;
+}
+export const getRealTimeSearch = async (count: number = 10): Promise<TopKeywordsResponse> => {
+  try {
+    const response = await apiClient.get<TopKeywordsResponse>('/keywords/top10', {
+      params: { count },
+    });
+
+    return response.data;
+  } catch (e) {
+    console.log('실시간 검색어 api 단 불러오기 오류', e);
+    throw e;
+  }
+};

--- a/src/components/molecules/mainpage/Meal/index.tsx
+++ b/src/components/molecules/mainpage/Meal/index.tsx
@@ -1,28 +1,43 @@
-'use client';
-interface MealComponentProps {
-  title: '아침' | '점심' | '저녁';
+type Props = {
+  title: string;
   items: string[];
-  highlight: boolean; //아침 점심 저녁 중 해당 시간대에는 highlight.
-}
-const MealComponent = ({ title, items, highlight }: MealComponentProps) => {
-  return (
-    <div
-      className={` border-grey-20 rounded  ${highlight ? 'bg-white ' : 'bg-white'} shadow-sm w-full `}
-    >
-      <div className='px-4 py-2 border-grey-40 '>
-        <h2
-          className={`text-sm  ${highlight ? 'text-blue-10 ' : 'text-blue-35'} font-semibold text-blue-10`}
-        >
-          {title}
-        </h2>
-      </div>
-      <ul className='px-4 py-2 text-sm text-black-40 space-y-1'>
-        {items.map((item, idx) => (
-          <li key={idx}>{item}</li>
-        ))}
-      </ul>
-    </div>
-  );
+  highlight?: boolean;
 };
 
-export default MealComponent;
+export default function MealComponent({ title, items, highlight }: Props) {
+  const mid = Math.ceil(items.length / 2);
+  const left = items.slice(0, mid);
+  const right = items.slice(mid);
+
+  return (
+    <div className='rounded-2xl border border-slate-200 p-4 md:p-6'>
+      <h3
+        className={`mb-3 text-base md:text-lg font-semibold ${
+          highlight ? 'text-blue-20' : 'text-slate-700'
+        }`}
+      >
+        {title}
+      </h3>
+
+      <div className='h-px bg-slate-200 mb-4' />
+
+      {/* 모바일 1열, md부터 2열 */}
+      <div className='grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-2'>
+        <ul className='space-y-2'>
+          {left.map((m, i) => (
+            <li key={`l-${i}`} className='text-slate-800'>
+              {m}
+            </li>
+          ))}
+        </ul>
+        <ul className='space-y-2'>
+          {right.map((m, i) => (
+            <li key={`r-${i}`} className='text-slate-800'>
+              {m}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/molecules/mainpage/RealTimeRank/index.tsx
+++ b/src/components/molecules/mainpage/RealTimeRank/index.tsx
@@ -75,17 +75,17 @@ export default function RealtimeRank({
 
   return (
     <section
-      className='rounded-lg border-grey-40 mt-2 bg-white shadow-md px-4 py-4'
+      className='rounded-lg  border-grey-40 mt-2 bg-white shadow-md px-4 py-4'
       aria-live='polite'
       aria-label='실시간 검색 순위'
     >
-      <div className='mb-3 flex items-center justify-between'>
-        <h3 className='text-base font-semibold text-gray-800'>{title}</h3>
-        <span className='text-xs text-gray-400'>데이터</span>
+      <div className='mb-4 flex items-center justify-between'>
+        <h3 className=' font-bold text-mju-primary text-2xl'>{title}</h3>
+        <span className='text-xs text-grey-40'>데이터</span>
       </div>
 
-      {loading && <p className='text-sm text-gray-400'>불러오는 중...</p>}
-      {!loading && error && <p className='text-sm text-gray-400'>{error}</p>}
+      {loading && <p className='text-sm text-gray-40'>불러오는 중...</p>}
+      {!loading && error && <p className='text-sm text-grey-40'>{error}</p>}
 
       {!loading && !error && (
         <ol className='divide-y text-sm'>
@@ -95,7 +95,7 @@ export default function RealtimeRank({
               <li key={item.keyword} className='flex items-center gap-3 py-2'>
                 <span
                   className={`w-6 h-6 shrink-0 grid place-items-center rounded-lg text-xs font-bold ${
-                    idx < 3 ? 'bg-mju-primary text-white' : 'bg-gray-100 text-grey-20'
+                    idx < 3 ? 'bg-mju-primary text-white' : 'bg-grey-40 text-grey-20'
                   }`}
                 >
                   {idx + 1}

--- a/src/components/molecules/mainpage/Tab/index.tsx
+++ b/src/components/molecules/mainpage/Tab/index.tsx
@@ -34,8 +34,9 @@ export default function TabComponent({ currentTab, setCurrentTab }: TabComponent
               aria-controls={`tab-panel-${value}`}
               onClick={() => setCurrentTab(value)}
               className={`
+                
                 relative pb-2 text-base transition-colors
-                ${active ? 'text-blue-20 font-semibold' : 'text-grey-20 hover:text-grey-40'}
+                ${active ? 'text-blue-15 font-semibold' : 'text-grey-20 '}
               `}
             >
               {label}
@@ -81,7 +82,7 @@ export default function TabComponent({ currentTab, setCurrentTab }: TabComponent
                   border transition-all
                   ${
                     active
-                      ? 'bg-mju-primary text-white border-blue-20 shadow-sm'
+                      ? 'bg-blue-20 text-white border-blue-20 shadow-sm'
                       : 'bg-white text-gray-700 border-gray-200 hover:bg-gray-50'
                   }
                 `}

--- a/src/components/organisms/CalendarGrid/index.tsx
+++ b/src/components/organisms/CalendarGrid/index.tsx
@@ -24,7 +24,15 @@ export default function CalendarGrid({ events, onYearChange, onMonthChange }: Ca
   const [year, setYear] = useState(() => new Date().getFullYear());
   const [month, setMonth] = useState(() => new Date().getMonth() + 1);
   const [currentDayIndex] = useState(() => new Date().getDay());
-  const weekdays = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일'];
+  const weekdays = [
+    { short: '일', full: '일요일' },
+    { short: '월', full: '월요일' },
+    { short: '화', full: '화요일' },
+    { short: '수', full: '수요일' },
+    { short: '목', full: '목요일' },
+    { short: '금', full: '금요일' },
+    { short: '토', full: '토요일' },
+  ];
   const calendarDays = useMemo(() => generateCalendarDays(year, month), [year, month]);
   const currentYear = new Date().getFullYear();
   const currentMonth = new Date().getMonth() + 1;
@@ -86,7 +94,12 @@ export default function CalendarGrid({ events, onYearChange, onMonthChange }: Ca
                   : 'bg-blue-05 text-blue-10',
               )}
             >
-              <Typography variant='body02'>{day}</Typography>
+              <span className='hidden md:block'>
+                <Typography variant='body02'>{day.full}</Typography>
+              </span>
+              <span className='block md:hidden'>
+                <Typography variant='body02'>{day.short}</Typography>
+              </span>
             </button>
           ))}
         </div>

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -7,7 +7,7 @@ export default function Header() {
         <div className='flex items-center  gap-3 text-[1.1rem] font-semibold text-[#0055ff]'>
           <FaBullhorn className='text-[1.4rem]' />
 
-          <span className='text-s'>현재 Version2 작업중입니다! MJS 일동</span>
+          <span className='text-s'>현재 Version2 작업중입니다! -MJS 일동-</span>
         </div>
       </div>
     </div>

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -7,7 +7,7 @@ export default function Header() {
         <div className='flex items-center  gap-3 text-[1.1rem] font-semibold text-[#0055ff]'>
           <FaBullhorn className='text-[1.4rem]' />
 
-          <span>현재 Version1 작업중입니다 _ MJS 일동</span>
+          <span className='text-s'>현재 Version2 작업중입니다! MJS 일동</span>
         </div>
       </div>
     </div>

--- a/src/components/organisms/Navbar.tsx
+++ b/src/components/organisms/Navbar.tsx
@@ -30,7 +30,7 @@ const Navbar = () => {
     if (!isLoggedIn) {
       e.preventDefault();
       toast.error('로그인이 필요한 서비스입니다.', { duration: 2000 });
-      trackNavClick('borad');
+      trackNavClick('board');
       navigate('/login');
     }
   };
@@ -94,22 +94,6 @@ const Navbar = () => {
             </Link>
           </li>
           <li>
-            <span
-              className='inline-flex items-center h-10 px-3 rounded-lg cursor-default text-white/60'
-              onClick={() => trackNavClick('market')}
-            >
-              벼룩시장
-            </span>
-          </li>
-          <li>
-            <span
-              className='inline-flex items-center h-10 px-3 rounded-lg cursor-default text-white/60'
-              onClick={() => trackNavClick('partnership')}
-            >
-              제휴
-            </span>
-          </li>
-          <li>
             <Link
               to='/notice'
               className='inline-flex items-center h-10 px-3 rounded-lg hover:bg-white/10'
@@ -128,12 +112,15 @@ const Navbar = () => {
             </Link>
           </li>
           <li>
-            <span
-              className='inline-flex items-center h-10 px-3 rounded-lg cursor-default text-white/60'
-              onClick={() => trackNavClick('job')}
+            <a
+              href='https://v0-university-career-data-platform.vercel.app/'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='inline-flex items-center h-10 px-3 rounded-lg hover:bg-white/10'
+              onClick={() => trackNavClick('mentor')}
             >
-              취업후기
-            </span>
+              멘토관 서비스
+            </a>
           </li>
           <li>
             <a
@@ -168,7 +155,7 @@ const Navbar = () => {
         </ul>
       </div>
 
-      {/* ✅ 모바일 검색바: 동일 컨테이너 폭으로 감싸 정렬 맞춤 */}
+      {/* 모바일 검색바 */}
       {showMobileSearch && (
         <div className='md:hidden'>
           <div className={`${CONTAINER}`}>
@@ -183,9 +170,22 @@ const Navbar = () => {
       {isOpen && (
         <ul className='flex flex-col md:hidden bg-[#002f6c] text-white text-sm font-medium list-none px-4 py-2 gap-1 leading-none border-t border-white/10'>
           <li>
-            <span className='inline-flex items-center px-3 h-10 rounded-lg cursor-default text-white/60'>
-              학과정보
-            </span>
+            <Link
+              to='/department'
+              onClick={closeMenu}
+              className='inline-flex items-center px-3 h-10 rounded-lg hover:bg-white/10'
+            >
+              학과별정보
+            </Link>
+          </li>
+          <li>
+            <Link
+              to='/academic-calendar'
+              onClick={closeMenu}
+              className='inline-flex items-center px-3 h-10 rounded-lg hover:bg-white/10'
+            >
+              학사일정
+            </Link>
           </li>
           <li>
             <Link
@@ -195,16 +195,6 @@ const Navbar = () => {
             >
               식단
             </Link>
-          </li>
-          <li>
-            <span className='inline-flex items-center px-3 h-10 rounded-lg cursor-default text-white/60'>
-              벼룩시장
-            </span>
-          </li>
-          <li>
-            <span className='inline-flex items-center px-3 h-10 rounded-lg cursor-default text-white/60'>
-              제휴
-            </span>
           </li>
           <li>
             <Link
@@ -221,13 +211,19 @@ const Navbar = () => {
               onClick={closeMenu}
               className='inline-flex items-center px-3 h-10 rounded-lg hover:bg-white/10'
             >
-              검색게시판
+              자유게시판
             </Link>
           </li>
           <li>
-            <span className='inline-flex items-center px-3 h-10 rounded-lg cursor-default text-white/60'>
-              취업후기
-            </span>
+            <a
+              href='https://v0-university-career-data-platform.vercel.app/'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='inline-flex items-center px-3 h-10 rounded-lg hover:bg-white/10'
+              onClick={closeMenu}
+            >
+              멘토관 서비스
+            </a>
           </li>
           <li>
             <a

--- a/src/components/organisms/Navbar.tsx
+++ b/src/components/organisms/Navbar.tsx
@@ -7,6 +7,8 @@ import { useNavTracking } from '../../hooks/gtm/useNavTracking';
 import toast from 'react-hot-toast';
 import SearchBar from '../atoms/SearchBar';
 
+const CONTAINER = 'mx-auto w-[90%] md:max-w-[1200px] px-4';
+
 const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
   const { isLoggedIn, logout } = useAuthStore();
@@ -14,16 +16,14 @@ const Navbar = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const toggleMenu = () => setIsOpen((prev) => !prev);
+  const toggleMenu = () => setIsOpen((p) => !p);
   const closeMenu = () => setIsOpen(false);
 
   const handleAuthClick = () => {
     if (isLoggedIn) {
       logout();
       toast.success('로그아웃 되었습니다.');
-    } else {
-      navigate('/login');
-    }
+    } else navigate('/login');
   };
 
   const handleBoardClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
@@ -46,9 +46,9 @@ const Navbar = () => {
   const showMobileSearch = !hideSearchRoutes.includes(location.pathname);
 
   return (
-    <nav className='sticky top-0 z-50 bg-mju-primary shadow-sm pt-[env(safe-area-inset-top)]'>
+    <nav className='sticky top-0 z-50 w-full bg-mju-primary shadow-sm pt-[env(safe-area-inset-top)]'>
       {/* 상단 바 */}
-      <div className='mx-auto md:max-w-[1200px] w-[90%] h-14 px-4 flex items-center justify-between'>
+      <div className={`${CONTAINER} h-14 flex items-center justify-between`}>
         <Link to='/' className='h-full'>
           <div className='flex items-center h-full'>
             <img src='/logo/MJS_darkLogo.svg' alt='MJS' className='w-17 h-auto' />
@@ -168,16 +168,18 @@ const Navbar = () => {
         </ul>
       </div>
 
-      {/* 모바일 전용 검색바 (얇게 + 살짝 여백) */}
+      {/* ✅ 모바일 검색바: 동일 컨테이너 폭으로 감싸 정렬 맞춤 */}
       {showMobileSearch && (
-        <div className='md:hidden px-4  pb-2'>
-          <div className='[&input]:h-10 [&input]:text-sm'>
-            <SearchBar className='h-10' />
+        <div className='md:hidden'>
+          <div className={`${CONTAINER}`}>
+            <div className='mt-2 pb-2 [&input]:h-10 [&input]:text-sm'>
+              <SearchBar className='h-10' />
+            </div>
           </div>
         </div>
       )}
 
-      {/* 모바일 메뉴 (block 제거 → inline-flex 정렬) */}
+      {/* 모바일 메뉴 */}
       {isOpen && (
         <ul className='flex flex-col md:hidden bg-[#002f6c] text-white text-sm font-medium list-none px-4 py-2 gap-1 leading-none border-t border-white/10'>
           <li>

--- a/src/components/organisms/Navbar.tsx
+++ b/src/components/organisms/Navbar.tsx
@@ -1,38 +1,35 @@
-import { Link, useNavigate } from 'react-router-dom';
-
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { HiMenu, HiX } from 'react-icons/hi';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { FiLogIn, FiLogOut } from 'react-icons/fi';
 import { useAuthStore } from '../../store/useAuthStore';
 import { useNavTracking } from '../../hooks/gtm/useNavTracking';
-import { useEffect } from 'react';
 import toast from 'react-hot-toast';
+import SearchBar from '../atoms/SearchBar';
 
 const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
   const { isLoggedIn, logout } = useAuthStore();
   const { trackNavClick } = useNavTracking();
-
   const navigate = useNavigate();
+  const location = useLocation();
 
   const toggleMenu = () => setIsOpen((prev) => !prev);
+  const closeMenu = () => setIsOpen(false);
+
   const handleAuthClick = () => {
     if (isLoggedIn) {
       logout();
       toast.success('로그아웃 되었습니다.');
-    } else navigate('/login');
+    } else {
+      navigate('/login');
+    }
   };
-  const closeMenu = () => setIsOpen(false);
 
   const handleBoardClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     if (!isLoggedIn) {
       e.preventDefault();
-
-      toast.error('로그인이 필요한 서비스입니다.', {
-        duration: 2000, // 2초 후 자동 닫힘
-        // pauseOnHover: true,
-        // onClose: () => navigate('/login'), // 닫힌 뒤 이동
-      });
+      toast.error('로그인이 필요한 서비스입니다.', { duration: 2000 });
       trackNavClick('borad');
       navigate('/login');
     }
@@ -44,9 +41,14 @@ const Navbar = () => {
     else root.classList.remove('overflow-hidden');
     return () => root.classList.remove('overflow-hidden');
   }, [isOpen]);
+
+  const hideSearchRoutes = ['/login', '/register'];
+  const showMobileSearch = !hideSearchRoutes.includes(location.pathname);
+
   return (
-    <nav className={`bg-mju-primary w-full  z-50 shadow-sm ${isOpen ? 'h-auto' : 'h-14'}`}>
-      <div className='mx-auto md:max-w-[1200px] w-[90%] h-full px-4 flex items-center justify-between'>
+    <nav className='sticky top-0 z-50 bg-mju-primary shadow-sm pt-[env(safe-area-inset-top)]'>
+      {/* 상단 바 */}
+      <div className='mx-auto md:max-w-[1200px] w-[90%] h-14 px-4 flex items-center justify-between'>
         <Link to='/' className='h-full'>
           <div className='flex items-center h-full'>
             <img src='/logo/MJS_darkLogo.svg' alt='MJS' className='w-17 h-auto' />
@@ -144,7 +146,6 @@ const Navbar = () => {
               띵지위키
             </a>
           </li>
-          {/* 로그인/로그아웃: 다른 메뉴와 동일한 형식 */}
           <li>
             <button
               onClick={handleAuthClick}
@@ -153,12 +154,12 @@ const Navbar = () => {
             >
               {isLoggedIn ? (
                 <>
-                  <FiLogOut size={16} className='block' />
+                  <FiLogOut size={16} />
                   로그아웃
                 </>
               ) : (
                 <>
-                  <FiLogIn size={16} className='block' />
+                  <FiLogIn size={16} />
                   로그인
                 </>
               )}
@@ -167,11 +168,20 @@ const Navbar = () => {
         </ul>
       </div>
 
-      {/* 모바일 메뉴 */}
+      {/* 모바일 전용 검색바 (얇게 + 살짝 여백) */}
+      {showMobileSearch && (
+        <div className='md:hidden px-4  pb-2'>
+          <div className='[&input]:h-10 [&input]:text-sm'>
+            <SearchBar className='h-10' />
+          </div>
+        </div>
+      )}
+
+      {/* 모바일 메뉴 (block 제거 → inline-flex 정렬) */}
       {isOpen && (
         <ul className='flex flex-col md:hidden bg-[#002f6c] text-white text-sm font-medium list-none px-4 py-2 gap-1 leading-none border-t border-white/10'>
           <li>
-            <span className='block px-3 h-10 rounded-lg cursor-default text-white/60 flex items-center'>
+            <span className='inline-flex items-center px-3 h-10 rounded-lg cursor-default text-white/60'>
               학과정보
             </span>
           </li>
@@ -179,18 +189,18 @@ const Navbar = () => {
             <Link
               to='/menu'
               onClick={closeMenu}
-              className='block px-3 h-10 rounded-lg flex items-center hover:bg-white/10'
+              className='inline-flex items-center px-3 h-10 rounded-lg hover:bg-white/10'
             >
               식단
             </Link>
           </li>
           <li>
-            <span className='block px-3 h-10 rounded-lg cursor-default text-white/60 flex items-center'>
+            <span className='inline-flex items-center px-3 h-10 rounded-lg cursor-default text-white/60'>
               벼룩시장
             </span>
           </li>
           <li>
-            <span className='block px-3 h-10 rounded-lg cursor-default text-white/60 flex items-center'>
+            <span className='inline-flex items-center px-3 h-10 rounded-lg cursor-default text-white/60'>
               제휴
             </span>
           </li>
@@ -198,7 +208,7 @@ const Navbar = () => {
             <Link
               to='/notice'
               onClick={closeMenu}
-              className='block px-3 h-10 rounded-lg flex items-center hover:bg-white/10'
+              className='inline-flex items-center px-3 h-10 rounded-lg hover:bg-white/10'
             >
               공지사항
             </Link>
@@ -207,13 +217,13 @@ const Navbar = () => {
             <Link
               to='/board'
               onClick={closeMenu}
-              className='block px-3 h-10 rounded-lg flex items-center hover:bg-white/10'
+              className='inline-flex items-center px-3 h-10 rounded-lg hover:bg-white/10'
             >
               검색게시판
             </Link>
           </li>
           <li>
-            <span className='block px-3 h-10 rounded-lg cursor-default text-white/60 flex items-center'>
+            <span className='inline-flex items-center px-3 h-10 rounded-lg cursor-default text-white/60'>
               취업후기
             </span>
           </li>
@@ -222,7 +232,7 @@ const Navbar = () => {
               href='https://namu.wiki/w/%EB%AA%85%EC%A7%80%EB%8C%80%ED%95%99%EA%B5%90'
               target='_blank'
               rel='noopener noreferrer'
-              className='block px-3 h-10 rounded-lg flex items-center hover:bg-white/10'
+              className='inline-flex items-center px-3 h-10 rounded-lg hover:bg-white/10'
               onClick={closeMenu}
             >
               띵지위키
@@ -234,15 +244,15 @@ const Navbar = () => {
                 handleAuthClick();
                 closeMenu();
               }}
-              className='flex items-center gap-2 px-3 h-10 rounded-lg hover:bg-white/10 transition-colors'
+              className='inline-flex items-center gap-2 px-3 h-10 rounded-lg hover:bg-white/10 transition-colors'
             >
               {isLoggedIn ? (
                 <>
-                  <FiLogOut size={16} className='block' /> 로그아웃
+                  <FiLogOut size={16} /> 로그아웃
                 </>
               ) : (
                 <>
-                  <FiLogIn size={16} className='block' /> 로그인
+                  <FiLogIn size={16} /> 로그인
                 </>
               )}
             </button>

--- a/src/components/organisms/sections/MealSection.tsx
+++ b/src/components/organisms/sections/MealSection.tsx
@@ -1,69 +1,72 @@
-import { fetchMealInfo } from '../../../api/main/meal-api';
-import type { MealInfo } from '../../../types/meal/mealInfo';
-import MealComponent from '../../molecules/mainpage/Meal';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FiPlus } from 'react-icons/fi';
+import { getMenus } from '../../../api/menu';
 
-const getCurrentMealTime = () => {
+import MealComponent from '../../molecules/mainpage/Meal';
+
+type UIMealKey = '아침' | '점심' | '저녁';
+type MenuCategory = 'BREAKFAST' | 'LUNCH' | 'DINNER';
+type MenuItem = { date: string; menuCategory: MenuCategory; meals: string[] };
+
+const DAY_KO = ['일', '월', '화', '수', '목', '금', '토'] as const;
+
+const getCurrentMealTime = (): UIMealKey => {
   const hour = new Date().getHours();
   if (hour < 10) return '아침';
   if (hour < 16) return '점심';
   return '저녁';
 };
 
-const getTodayString = () => {
-  const today = new Date();
-  const mm = String(today.getMonth() + 1).padStart(2, '0');
-  const day = String(today.getDate()).padStart(2, '0');
-  const dayOfWeek = ['일', '월', '화', '수', '목', '금', '토'][today.getDay()];
-  return `${mm}.${day} ( ${dayOfWeek} )`;
+const getTodayLabel = () => {
+  const d = new Date();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  const dow = DAY_KO[d.getDay()];
+  return `${mm}.${dd} (${dow})`;
 };
+
+const normalizeLabel = (s: string) => s.replace(/\s+/g, '');
+const catToUiKey = (c: MenuCategory): UIMealKey =>
+  c === 'BREAKFAST' ? '아침' : c === 'LUNCH' ? '점심' : '저녁';
 
 const MealSection = () => {
   const current = getCurrentMealTime();
   const navigator = useNavigate();
-  const handlePlusClick = () => {
-    navigator('/menu');
-  };
 
-  const [todayMeals, setTodayMeals] = useState<Record<'아침' | '점심' | '저녁', string[]>>({
+  const handlePlusClick = () => navigator('/menu');
+
+  const [todayMeals, setTodayMeals] = useState<Record<UIMealKey, string[]>>({
     아침: [],
     점심: [],
     저녁: [],
   });
 
-  //주말인 경우의 예외처리 로직
   const isWeekend = () => {
     const day = new Date().getDay();
     return day === 0 || day === 6;
   };
 
   useEffect(() => {
-    const fetchingMealSection = async () => {
+    (async () => {
       try {
-        const response = await fetchMealInfo();
-        const todayStr = getTodayString();
-        const meals = response.data.filter((item) => item.date === todayStr);
+        // getMenus가 Axios라면: const list: MenuItem[] = (await getMenus()).data;
+        const list: MenuItem[] = await getMenus();
 
-        const mapped: Record<'아침' | '점심' | '저녁', string[]> = {
-          아침: [],
-          점심: [],
-          저녁: [],
-        };
+        const today = getTodayLabel();
+        const todays = list.filter((x) => normalizeLabel(x.date) === normalizeLabel(today));
 
-        meals.forEach((m: MealInfo) => {
-          if (m.menuCategory === 'BREAKFAST') mapped['아침'] = m.meals;
-          if (m.menuCategory === 'LUNCH') mapped['점심'] = m.meals;
-          if (m.menuCategory === 'DINNER') mapped['저녁'] = m.meals;
+        const next: Record<UIMealKey, string[]> = { 아침: [], 점심: [], 저녁: [] };
+        todays.forEach((m) => {
+          const key = catToUiKey(m.menuCategory);
+          next[key] = m.meals ?? [];
         });
 
-        setTodayMeals(mapped);
+        setTodayMeals(next);
       } catch (e) {
-        console.log('식단 불러오는 중 오류 발생', e);
+        console.error('식단 불러오는 중 오류 발생', e);
       }
-    };
-    fetchingMealSection();
+    })();
   }, []);
 
   return (
@@ -76,18 +79,16 @@ const MealSection = () => {
       </div>
 
       {isWeekend() ? (
-        <div className=' text-grey-40 text-sm'>주말에는 학식이 제공되지 않습니다.</div>
+        <div className='text-grey-40 text-sm'>주말에는 학식이 제공되지 않습니다.</div>
       ) : (
         <div className='w-full md:flex-row gap-4 justify-start'>
-          <MealComponent
-            key={current}
-            title={current}
-            items={todayMeals[current]}
-            highlight={true}
-          />
+          {/* 현재 끼만 보여줄 거면 아래 한 개만, 
+             세 끼 모두 보여주고 현재 끼만 하이라이트하려면 3개 렌더 + highlight 조건 분기 */}
+          <MealComponent key={current} title={current} items={todayMeals[current]} highlight />
         </div>
       )}
     </section>
   );
 };
+
 export default MealSection;

--- a/src/components/organisms/sections/NoticeSection.tsx
+++ b/src/components/organisms/sections/NoticeSection.tsx
@@ -11,9 +11,8 @@ const NoticeSection = () => {
   const selectedCategory = selectedTab;
   const recentYear = new Date().getFullYear();
   const navigator = useNavigate();
-  const handleClickPlus = () => {
-    navigator('/notice');
-  };
+
+  const handleClickPlus = () => navigator('/notice');
 
   useEffect(() => {
     const fetchingData = async () => {
@@ -26,30 +25,43 @@ const NoticeSection = () => {
     };
     fetchingData();
   }, [selectedTab]);
+
   return (
     <div>
       <div className='flex justify-between mt-4'>
-        <h1 className='text-xl font-bold text-mju-primary mb-4 '>공지사항</h1>
-        <span>
-          <FiPlus onClick={handleClickPlus} size={20} />
-        </span>
+        <h1 className='text-xl font-bold text-mju-primary mb-4'>공지사항</h1>
+        <button
+          type='button'
+          onClick={handleClickPlus}
+          className='h-6 w-6 grid place-items-center rounded hover:bg-gray-100 active:bg-gray-200'
+          aria-label='공지사항 더보기'
+          title='공지사항 더보기'
+        >
+          <FiPlus size={20} />
+        </button>
       </div>
-      <TabComponent currentTab={selectedTab} setCurrentTab={setSelectedTab}></TabComponent>
-      <div className='grid grid-cols-1 gap-2 mt-5 '>
+
+      <TabComponent currentTab={selectedTab} setCurrentTab={setSelectedTab} />
+
+      <div className='grid grid-cols-1 gap-2 mt-5'>
         {selectedInfo.map((data, idx) => (
-          <div className='bg-grey-05 '>
+          <div key={idx} className='bg-white'>
             <a
               href={data.link}
               target='_blank'
               rel='noopener noreferrer'
-              key={idx}
-              className='block p-4 border border-grey-10 rounded-xl shadow-sm hover:shadow-md transition-shadow'
+              className='
+                block p-4 border border-grey-10 rounded-xl shadow-sm
+                
+                md:hover:bg-grey-10 md:hover:shadow-md   /* 데스크톱 hover */
+                active:bg-grey-10                         /* 모바일/터치 press */
+                focus-visible:outline-none
+                focus-visible:ring-2 focus-visible:ring-mju-primary/30
+              '
             >
-              <h3 className='text-lg font-semibold text-blue-800 truncate'>{data.title}</h3>
+              <h3 className='text-lg font-semibold text-black truncate'>{data.title}</h3>
               <div className='mt-2 text-sm text-gray-600'>
-                <p>
-                  <span className='font-medium'>{new Date(data.date).toLocaleDateString()}</span>
-                </p>
+                <span className='font-medium'>{new Date(data.date).toLocaleDateString()}</span>
               </div>
             </a>
           </div>

--- a/src/components/templates/LayoutForMain.tsx
+++ b/src/components/templates/LayoutForMain.tsx
@@ -25,7 +25,7 @@ const LayoutForMain = ({ children }: LayoutProps) => {
       <Navbar />
 
       <main className='flex-1 w-full max-w-[1280px] mx-auto flex flex-col px-4 md:px-0'>
-        <div className='hidden md:block'>{shouldShowHeader && <Header />}</div>
+        <div className='block'>{shouldShowHeader && <Header />}</div>
 
         <div className='flex flex-col md:flex-row gap-4 mt-6'>
           {/* 좌 컬럼: 검색 + 메인 콘텐츠 */}

--- a/src/components/templates/LayoutForMain.tsx
+++ b/src/components/templates/LayoutForMain.tsx
@@ -31,7 +31,9 @@ const LayoutForMain = ({ children }: LayoutProps) => {
           {/* 좌 컬럼: 검색 + 메인 콘텐츠 */}
 
           <div className='min-w-0 w-full md:w-2/3 flex flex-col gap-3'>
-            <SearchBar />
+            <div className='hidden'>
+              <SearchBar />
+            </div>
             <div className='md:hidden'>
               <ProfileComponent />
             </div>

--- a/src/components/templates/LayoutForMain.tsx
+++ b/src/components/templates/LayoutForMain.tsx
@@ -34,7 +34,7 @@ const LayoutForMain = ({ children }: LayoutProps) => {
             <div className='hidden'>
               <SearchBar />
             </div>
-            <div className='md:hidden'>
+            <div className='hidden'>
               <ProfileComponent />
             </div>
 

--- a/src/components/templates/LayoutForMain.tsx
+++ b/src/components/templates/LayoutForMain.tsx
@@ -8,7 +8,7 @@ import WeatherComponent from '../molecules/mainpage/Weather';
 import type { ReactNode } from 'react';
 import AdCarousel from '../molecules/mainpage/Advertise';
 import RealtimeRank from '../molecules/mainpage/RealTimeRank';
-import AcademicSchedulePanel from '../molecules/mainpage/AcademicSchedulePanel/index.tsx';
+
 import HotBoardList from '../molecules/mainpage/HotBoardList.tsx';
 
 interface LayoutProps {
@@ -45,9 +45,7 @@ const LayoutForMain = ({ children }: LayoutProps) => {
             <div className='hidden md:block'>
               <ProfileComponent />
             </div>
-            <div className='hidden md:block'>
-              <AcademicSchedulePanel />
-            </div>
+
             <div className='hidden md:block'>
               <AdCarousel />
             </div>

--- a/src/components/templates/LayoutForMain.tsx
+++ b/src/components/templates/LayoutForMain.tsx
@@ -27,7 +27,7 @@ const LayoutForMain = ({ children }: LayoutProps) => {
       <main className='flex-1 w-full max-w-[1280px] mx-auto flex flex-col px-4 md:px-0'>
         <div className='block'>{shouldShowHeader && <Header />}</div>
 
-        <div className='flex flex-col md:flex-row gap-4 mt-6'>
+        <div className='flex flex-col md:flex-row gap-4'>
           {/* 좌 컬럼: 검색 + 메인 콘텐츠 */}
 
           <div className='min-w-0 w-full md:w-2/3 flex flex-col gap-3'>

--- a/src/components/templates/LayoutForMain.tsx
+++ b/src/components/templates/LayoutForMain.tsx
@@ -44,7 +44,7 @@ const LayoutForMain = ({ children }: LayoutProps) => {
               <ProfileComponent />
             </div>
             <div className='hidden md:block'>
-              <WeatherComponent />
+              <AcademicSchedulePanel />
             </div>
             <div className='hidden md:block'>
               <AdCarousel />
@@ -53,7 +53,7 @@ const LayoutForMain = ({ children }: LayoutProps) => {
               <RealtimeRank />
             </div>
             <div className='hidden md:block '>
-              <AcademicSchedulePanel />
+              <WeatherComponent />
             </div>
             <div className='hidden md:block'>
               <HotBoardList />

--- a/src/pages/academic-calendar/index.tsx
+++ b/src/pages/academic-calendar/index.tsx
@@ -11,35 +11,48 @@ export default function AcademicCalendar() {
   const [events, setEvents] = useState<CalendarEventItem[] | null>(null);
 
   useEffect(() => {
-    const getEvents = async () => {
+    (async () => {
       try {
         const res = await getAcademicEvents({ year: currentYear });
         setEvents(res);
       } catch (err) {
         console.error(err);
       }
-    };
-    getEvents();
+    })();
   }, [currentYear]);
 
   return (
-    <div className='px-7 py-12 flex flex-col gap-6'>
+    <div className='px-4 md:px-7 py-8 md:py-12 flex flex-col gap-4 md:gap-6'>
       <Typography variant='heading01' className='text-mju-primary'>
         학사일정
       </Typography>
       <Divider />
-      <div className='flex gap-6'>
-        <div className='flex-2/3'>
+
+      <section
+        className='
+          grid gap-4 md:gap-6
+          grid-cols-1
+          md:grid-cols-[2fr_1fr]
+        '
+      >
+        <div className='w-full'>
           <CalendarGrid
             events={events}
             onYearChange={setCurrentYear}
             onMonthChange={setCurrentMonth}
           />
         </div>
-        <div className='flex-1/3'>
+
+        <aside
+          className='
+            hidden md:block
+            w-full
+          '
+          aria-hidden={false}
+        >
           <CalendarList events={events} month={currentMonth} />
-        </div>
-      </div>
+        </aside>
+      </section>
     </div>
   );
 }

--- a/src/pages/academic-calendar/index.tsx
+++ b/src/pages/academic-calendar/index.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react';
 import Divider from '../../components/atoms/Divider';
 import { Typography } from '../../components/atoms/Typography';
 import CalendarGrid, { type CalendarEventItem } from '../../components/organisms/CalendarGrid';
-import { getAcademicEvents } from '../../api/calendar';
 import CalendarList from '../../components/organisms/CalendarList';
+import { getAcademicEvents } from '../../api/calendar';
 
 export default function AcademicCalendar() {
   const [currentYear, setCurrentYear] = useState<number>(new Date().getFullYear());
@@ -23,10 +23,12 @@ export default function AcademicCalendar() {
 
   return (
     <div className='px-4 md:px-7 py-8 md:py-12 flex flex-col gap-4 md:gap-6'>
-      <Typography variant='heading01' className='text-mju-primary '>
-        <span className='md:text-2xl text-xl'>학사일정</span>
+      <Typography variant='heading01' className='text-mju-primary'>
+        <span className='md:text-2xl text-xl md:hidden'>학사일정</span>
       </Typography>
-      <Divider />
+      <span className='md:hidden'>
+        <Divider />
+      </span>
 
       <section
         className='
@@ -43,13 +45,7 @@ export default function AcademicCalendar() {
           />
         </div>
 
-        <aside
-          className='
-            hidden md:block
-            w-full
-          '
-          aria-hidden={false}
-        >
+        <aside className='hidden md:block w-full' aria-hidden={false}>
           <CalendarList events={events} month={currentMonth} />
         </aside>
       </section>

--- a/src/pages/academic-calendar/index.tsx
+++ b/src/pages/academic-calendar/index.tsx
@@ -23,8 +23,8 @@ export default function AcademicCalendar() {
 
   return (
     <div className='px-4 md:px-7 py-8 md:py-12 flex flex-col gap-4 md:gap-6'>
-      <Typography variant='heading01' className='text-mju-primary'>
-        학사일정
+      <Typography variant='heading01' className='text-mju-primary '>
+        <span className='md:text-2xl text-xl'>학사일정</span>
       </Typography>
       <Divider />
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,10 +12,13 @@ const Main = () => {
       </div>
       <NoticeSection />
       <NewsSection />
-      <div>
+
+      <div className='hidden md:block'>
+        <BroadcastSection />
+      </div>
+      <div className='md:block '>
         <AcademicCalendar />
       </div>
-      <BroadcastSection />
     </LayoutForMain>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,7 @@ import MealSection from '../components/organisms/sections/MealSection';
 import NoticeSection from '../components/organisms/sections/NoticeSection';
 import NewsSection from '../components/organisms/sections/NewsSection';
 import BroadcastSection from '../components/organisms/sections/BroadcastSection';
-
+import AcademicCalendar from './academic-calendar';
 const Main = () => {
   return (
     <LayoutForMain>
@@ -12,6 +12,9 @@ const Main = () => {
       </div>
       <NoticeSection />
       <NewsSection />
+      <div>
+        <AcademicCalendar />
+      </div>
       <BroadcastSection />
     </LayoutForMain>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,19 +4,27 @@ import NoticeSection from '../components/organisms/sections/NoticeSection';
 import NewsSection from '../components/organisms/sections/NewsSection';
 import BroadcastSection from '../components/organisms/sections/BroadcastSection';
 import AcademicCalendar from './academic-calendar';
+
 const Main = () => {
   return (
     <LayoutForMain>
-      <div className='hidden md:block'>
+      <div className='hidden md:block md:order-1'>
         <MealSection />
       </div>
-      <NoticeSection />
-      <NewsSection />
 
-      <div className='hidden md:block'>
+      <div className='order-1 md:order-2'>
+        <NoticeSection />
+      </div>
+
+      <div className='order-3 md:order-3'>
+        <NewsSection />
+      </div>
+
+      <div className='hidden md:block md:order-4'>
         <BroadcastSection />
       </div>
-      <div className='md:block '>
+
+      <div className='order-2 md:hidden'>
         <AcademicCalendar />
       </div>
     </LayoutForMain>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,7 +7,9 @@ import BroadcastSection from '../components/organisms/sections/BroadcastSection'
 const Main = () => {
   return (
     <LayoutForMain>
-      <MealSection />
+      <div className='hidden md:block'>
+        <MealSection />
+      </div>
       <NoticeSection />
       <NewsSection />
       <BroadcastSection />

--- a/src/pages/menu/index.tsx
+++ b/src/pages/menu/index.tsx
@@ -20,6 +20,7 @@ export default function Menu() {
     (async () => {
       try {
         const res = await getMenus();
+        console.log(res);
         setContents(res);
       } catch (e) {
         toast.error('식단을 불러오는 중 오류가 발생했습니다!', e);


### PR DESCRIPTION
#104 
<img width="874" height="999" alt="스크린샷 2025-09-11 오후 5 26 45" src="https://github.com/user-attachments/assets/27ddd1af-ef85-4b4d-a017-8f5deb77d7e8" />


 ### 주요 변경 사항 -> 전체적인 디자인 syncing.

1. 학식(식단표) 디자인 개선  
   - 피그마에 디자이너님이 올려주신 시안을 그대로 반영했습니다.  
   - 아침/점심/저녁 중 데이터가 없는 경우, 존재하는 식단으로 대체 표시되도록 처리했습니다.  
<img width="861" height="330" alt="스크린샷 2025-09-11 오후 5 27 45" src="https://github.com/user-attachments/assets/ddea9f36-5ae9-4035-887e-49e6dda25bdb" />

2. 학사일정  
   - 날짜 표시 및 포지션 레이아웃을 변경하여 가독성을 개선했습니다.  
<img width="885" height="1003" alt="스크린샷 2025-09-11 오후 5 27 26" src="https://github.com/user-attachments/assets/1d7facc3-adc0-48cb-b03a-1473175cc589" />

3. 모바일 버전 개선  
   - 메인페이지에서 누락된 기능들을 보강했습니다.  
   - 로그인 페이지는 화면 최하단으로 위치를 변경하려했지만, 또 모바일 디자인에는 없더군요 이 부분은 논의가 필요해 보입니다.

4. 실시간 검색 순위  
   - 항목 클릭 시 해당 검색 결과로 이동할 수 있도록 리다이렉션 기능을 추가했습니다.  
   - 현재 API 연동은 완료했으나, 데이터가 아직 부족하여 **통합 이후 리다이렉션 로직을 본격적으로 적용**할 예정입니다.  

---

### 기타
- UI/UX 피드백 반영 및 세부 스타일링 조정.
- 개인적으로 디자이너님은 공지사항 글씨를 검정색으로 하셨는데, 전 색깔이 있는게 나은거같은데 어떻게 생각하시는지요?