### PR TITLE
<Feat> 학사일정 모바일 페이지 추가

### DIFF
--- a/src/components/molecules/Calendar/index.tsx
+++ b/src/components/molecules/Calendar/index.tsx
@@ -8,6 +8,7 @@ interface CalendarProps {
   onYearChange: (year: number) => void;
   onMonthChange: (month: number) => void;
   events: CalendarMonthlyRes | null;
+  onDateSelect: (date: Date) => void;
 }
 
 export default function Calendar({
@@ -15,6 +16,7 @@ export default function Calendar({
   onYearChange,
   onMonthChange,
   events: initialEvents,
+  onDateSelect,
 }: CalendarProps) {
   const date = new Date();
   const dayMap = ['일', '월', '화', '수', '목', '금', '토'];
@@ -121,6 +123,9 @@ export default function Calendar({
       return `${y}-${m}-${d}`;
     };
 
+    /**
+     * 이전 달
+     */
     for (let i = startDayOfWeek; i > 0; i--) {
       const day = lastDayOfPrevMonth - i + 1;
       const dayOfWeek = startDayOfWeek - i;
@@ -132,9 +137,13 @@ export default function Calendar({
         outdated: true,
         weekend: dayOfWeek === 0 || dayOfWeek === 6,
         events: getEventsForDate(currentDateStr),
+        fullDate: date,
       });
     }
 
+    /**
+     * 현재 달
+     */
     for (let i = 1; i <= daysInMonth; i++) {
       const dayOfWeek = (startDayOfWeek + i - 1) % 7;
       const date = new Date(currentYear, currentMonth - 1, i);
@@ -145,6 +154,7 @@ export default function Calendar({
         outdated: false,
         weekend: dayOfWeek === 0 || dayOfWeek === 6,
         events: getEventsForDate(currentDateStr),
+        fullDate: date,
       });
     }
 
@@ -152,6 +162,9 @@ export default function Calendar({
     const totalGridCells = totalCellsNeeded > 35 ? 42 : 35;
     const remainingCells = totalGridCells - totalCellsNeeded;
 
+    /**
+     * 다음 달
+     */
     for (let i = 1; i <= remainingCells; i++) {
       const dayOfWeek = (startDayOfWeek + daysInMonth + i - 1) % 7;
       const date = new Date(currentYear, currentMonth, i);
@@ -162,6 +175,7 @@ export default function Calendar({
         outdated: true,
         weekend: dayOfWeek === 0 || dayOfWeek === 6,
         events: getEventsForDate(currentDateStr),
+        fullDate: date,
       });
     }
 
@@ -229,6 +243,7 @@ export default function Calendar({
                 outdated={item.outdated}
                 weekend={item.weekend}
                 events={item.events}
+                onClick={() => onDateSelect?.(item.fullDate)}
               />
             ))}
           </div>
@@ -252,11 +267,18 @@ interface CalendarItemProps {
   outdated?: boolean;
   weekend?: boolean;
   events?: CalendarEvent[];
+  onClick: () => void;
 }
 
-function CalendarItem({ day, outdated = false, weekend = false, events = [] }: CalendarItemProps) {
+function CalendarItem({
+  day,
+  outdated = false,
+  weekend = false,
+  events = [],
+  onClick,
+}: CalendarItemProps) {
   return (
-    <button>
+    <button onClick={onClick}>
       <div className='min-h-15 p-1 flex flex-col hover:bg-blue-05'>
         <span
           className={clsx(

--- a/src/components/molecules/Calendar/index.tsx
+++ b/src/components/molecules/Calendar/index.tsx
@@ -15,14 +15,14 @@ export default function Calendar({
   className,
   onYearChange,
   onMonthChange,
-  events: initialEvents,
+  events,
   onDateSelect,
 }: CalendarProps) {
   const date = new Date();
   const dayMap = ['일', '월', '화', '수', '목', '금', '토'];
   const [currentYear, setCurrentYear] = useState(date.getFullYear());
   const [currentMonth, setCurrentMonth] = useState(date.getMonth() + 1);
-  const [events] = useState(initialEvents);
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
 
   /**
    * 시스템 현재 날짜값 보관
@@ -31,6 +31,27 @@ export default function Calendar({
   const actualCurrentYear = today.getFullYear();
   const actualCurrentMonth = today.getMonth() + 1;
   const actualCurrentDayOfWeek = today.getDay();
+  const actualCurrentDay = today.getDate();
+
+  /**
+   * 두 Date 객체가 같은 날짜인지 비교
+   */
+  const isSameDate = (date1: Date | null, date2: Date | null) => {
+    if (!date1 || !date2) return false;
+    return (
+      date1.getFullYear() === date2.getFullYear() &&
+      date1.getMonth() === date2.getMonth() &&
+      date1.getDate() === date2.getDate()
+    );
+  };
+
+  /**
+   * 날짜 클릭 핸들러
+   */
+  const handleDateClick = (date: Date) => {
+    setSelectedDate(date);
+    onDateSelect?.(date);
+  };
 
   /**
    * 이전 달 버튼 핸들러
@@ -148,6 +169,10 @@ export default function Calendar({
       const dayOfWeek = (startDayOfWeek + i - 1) % 7;
       const date = new Date(currentYear, currentMonth - 1, i);
       const currentDateStr = formatDate(date);
+      const isToday =
+        currentYear === actualCurrentYear &&
+        currentMonth === actualCurrentMonth &&
+        i === actualCurrentDay;
 
       days.push({
         day: i,
@@ -155,6 +180,7 @@ export default function Calendar({
         weekend: dayOfWeek === 0 || dayOfWeek === 6,
         events: getEventsForDate(currentDateStr),
         fullDate: date,
+        isToday: isToday,
       });
     }
 
@@ -180,7 +206,14 @@ export default function Calendar({
     }
 
     return days;
-  }, [currentYear, currentMonth, allEvents]);
+  }, [
+    currentYear,
+    currentMonth,
+    allEvents,
+    actualCurrentYear,
+    actualCurrentMonth,
+    actualCurrentDay,
+  ]);
 
   return (
     <section>
@@ -236,16 +269,26 @@ export default function Calendar({
            * 이벤트 표시
            */}
           <div className='w-full grid grid-cols-7'>
-            {calendarDays.map((item, index) => (
-              <CalendarItem
-                key={index}
-                day={item.day}
-                outdated={item.outdated}
-                weekend={item.weekend}
-                events={item.events}
-                onClick={() => onDateSelect?.(item.fullDate)}
-              />
-            ))}
+            {calendarDays.map((item, index) => {
+              /**
+               * 오늘 날짜 이거나 선택한 날짜가 있는 경우 highlight 표시
+               */
+              const isSelected = isSameDate(item.fullDate, selectedDate);
+              const isToday = item.isToday;
+              const isHighlighted = selectedDate !== null ? isSelected : isToday;
+
+              return (
+                <CalendarItem
+                  key={index}
+                  day={item.day}
+                  outdated={item.outdated}
+                  weekend={item.weekend}
+                  events={item.events}
+                  onClick={() => handleDateClick(item.fullDate)}
+                  isHighlighted={isHighlighted}
+                />
+              );
+            })}
           </div>
         </div>
       </div>
@@ -268,28 +311,39 @@ interface CalendarItemProps {
   weekend?: boolean;
   events?: CalendarEvent[];
   onClick: () => void;
+  isHighlighted?: boolean;
 }
 
+/**
+ * 캘린더 날짜 아이템
+ */
 function CalendarItem({
   day,
   outdated = false,
   weekend = false,
   events = [],
   onClick,
+  isHighlighted = false,
 }: CalendarItemProps) {
   return (
-    <button onClick={onClick}>
-      <div className='min-h-15 p-1 flex flex-col hover:bg-blue-05'>
+    <button onClick={onClick} disabled={outdated}>
+      <div
+        className={clsx(
+          'min-h-15 py-1 flex flex-col',
+          !outdated && 'hover:bg-blue-05 cursor-pointer',
+          isHighlighted && !outdated && 'bg-blue-05',
+        )}
+      >
         <span
           className={clsx(
-            'text-caption04 text-start',
+            'mx-1 text-caption04 text-start',
             outdated && 'text-grey-40',
             weekend && 'text-error',
           )}
         >
           {String(day).padStart(2, '0')}
         </span>
-        <div className='h-[0.5px] bg-grey-10' />
+        <div className='mx-1 h-[0.5px] bg-grey-10' />
 
         {/**
          * 이벤트 막대(bar) 렌더링 영역

--- a/src/components/molecules/sections/academic-schedule-widget.tsx
+++ b/src/components/molecules/sections/academic-schedule-widget.tsx
@@ -31,7 +31,8 @@ export default function AcademicScheduleWidget({ className, events }: AcademicSc
    * 부모 컴포넌트로부터 이벤트 데이터를 받지 못했으면 새롭게 api를 요청합니다.
    */
   useEffect(() => {
-    if (!events) getData();
+    if (events) setScheduleData(events);
+    else getData();
   }, [events]);
 
   /**
@@ -83,14 +84,14 @@ export default function AcademicScheduleWidget({ className, events }: AcademicSc
                     <div className={`w-12 flex items-center justify-center ${category.className}`}>
                       <span className='text-[12px] text-white'>{category.label}</span>
                     </div>
-                    <div className='flex flex-col gap-0.5'>
+                    <div className='flex-1 flex flex-col gap-0.5'>
                       <ul>
                         {events.map((event) => (
                           <li key={event.id} className='flex items-center'>
                             <span className='inline-block w-20 text-[12px] text-grey-40'>
                               {formatDateRange(event.startDate, event.endDate)}
                             </span>
-                            <span className='text-[14px] text-black line-clamp-1'>
+                            <span className='flex-1 text-[14px] text-black line-clamp-1'>
                               {removeBracketedContent(event.description)}
                             </span>
                           </li>
@@ -132,20 +133,9 @@ const formatDateRange = (startDate: string, endDate: string): string => {
 };
 
 /**
- * 이벤트 제목에서 대괄호를 제거하는 함수입니다.
- *
- * Removes all content, including the square brackets, that is enclosed
- * within [ and ] from a given string.
- *
- * @param inputString The string to process.
- * @returns The processed string with bracketed content removed.
+ * 이벤트 제목에서 대괄호 제거
  */
 function removeBracketedContent(inputString: string): string {
-  // Regular expression to match any character(s) (non-greedy, represented by '.*?' or '[^\]]*')
-  // enclosed between a literal '[' and a literal ']'. The 'g' flag ensures
-  // all occurrences are replaced.
   const regex = /\[.*?\]/g;
-
-  // Replace all matches of the regex with an empty string.
   return inputString.replace(regex, '');
 }

--- a/src/components/molecules/sections/daily-academic-schedule-widget.tsx
+++ b/src/components/molecules/sections/daily-academic-schedule-widget.tsx
@@ -1,0 +1,96 @@
+import type { CalendarMonthlyRes, CalendarScheduleItem } from '@/api/main/calendar';
+import { useMemo } from 'react';
+import clsx from 'clsx';
+
+type ScheduleCategoryKey = 'all' | 'undergrad' | 'graduate' | 'holiday';
+
+const scheduleCategories: Record<ScheduleCategoryKey, { label: string; className: string }> = {
+  all: { label: '전체', className: 'bg-blue-20' },
+  undergrad: { label: '학부', className: 'bg-mju-primary' },
+  graduate: { label: '대학원', className: 'bg-grey-40' },
+  holiday: { label: '휴일', className: 'bg-error' },
+};
+
+interface DailyAcademicScheduleWidgetProps {
+  date: Date;
+  events: CalendarMonthlyRes | null;
+}
+
+function DailyAcademicScheduleWidget({ date, events }: DailyAcademicScheduleWidgetProps) {
+  /**
+   * 오늘 날짜 표시
+   */
+  function formatDateWithDay() {
+    const dayMap = ['일', '월', '화', '수', '목', '금', '토'];
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const dayOfWeek = dayMap[date.getDay()];
+    return `${month}.${day} (${dayOfWeek})`;
+  }
+
+  /**
+   * 이벤트 날짜별 필터링
+   */
+  const filteredEvents = useMemo(() => {
+    if (!events) {
+      return [];
+    }
+    const selectedDateStr = getISODateString(date);
+    const allEvents: (CalendarScheduleItem & { category: ScheduleCategoryKey })[] = [
+      ...events.all.map((e) => ({ ...e, category: 'all' as const })),
+      ...events.undergrad.map((e) => ({ ...e, category: 'undergrad' as const })),
+      ...events.graduate.map((e) => ({ ...e, category: 'graduate' as const })),
+      ...events.holiday.map((e) => ({ ...e, category: 'holiday' as const })),
+    ];
+    return allEvents.filter((event) => {
+      return selectedDateStr >= event.startDate && selectedDateStr <= event.endDate;
+    });
+  }, [date, events]);
+
+  return (
+    <section>
+      <div className='min-h-16 flex gap-4'>
+        <span className='text-body03 text-mju-primary'>{formatDateWithDay()}</span>
+        <div className='flex-1 flex flex-col gap-1'>
+          {filteredEvents.length > 0 ? (
+            filteredEvents.map((event) => {
+              const categoryInfo = scheduleCategories[event.category];
+              return (
+                <div key={event.id} className='flex gap-2 items-center'>
+                  <div className={clsx('w-2.5 h-2.5', categoryInfo.className)} />
+                  <div className='flex-1'>
+                    <span key={event.id} className='text-caption02 line-clamp-1'>
+                      {removeBracketedContent(event.description)}
+                    </span>
+                  </div>
+                </div>
+              );
+            })
+          ) : (
+            <span className='text-caption02 text-grey-20'>일정이 없습니다</span>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export { DailyAcademicScheduleWidget };
+
+/**
+ * Date 객체를 'YYYY-MM-DD' 형식의 문자열로 변환
+ */
+function getISODateString(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * 이벤트 제목에서 대괄호 제거
+ */
+function removeBracketedContent(inputString: string): string {
+  const regex = /\[.*?\]/g;
+  return inputString.replace(regex, '');
+}

--- a/src/pages/academic-calendar/index.tsx
+++ b/src/pages/academic-calendar/index.tsx
@@ -8,6 +8,7 @@ import CalendarGrid from '@/components/organisms/CalendarGrid';
 import CalendarList from '@/components/organisms/CalendarList';
 import { getAcademicCalendar, type CalendarMonthlyRes } from '@/api/main/calendar';
 import Calendar from '@/components/molecules/Calendar';
+import { DailyAcademicScheduleWidget } from '@/components/molecules/sections/daily-academic-schedule-widget';
 
 export default function AcademicCalendar() {
   const [, setIsLoading] = useState(true);
@@ -15,6 +16,8 @@ export default function AcademicCalendar() {
   const [currentYear, setCurrentYear] = useState<number>(new Date().getFullYear());
   const [currentMonth, setCurrentMonth] = useState<number>(new Date().getMonth() + 1);
   const [events, setEvents] = useState<CalendarMonthlyRes | null>(null);
+  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+
   const { isDesktop } = useResponsive();
 
   useEffect(() => {
@@ -102,7 +105,14 @@ export default function AcademicCalendar() {
               events={events}
               onYearChange={setCurrentYear}
               onMonthChange={setCurrentMonth}
+              onDateSelect={(date) => {
+                console.log(date);
+                setSelectedDate(date);
+              }}
             />
+          </div>
+          <div>
+            <DailyAcademicScheduleWidget date={selectedDate} events={events} />
           </div>
           <div>
             <AcademicScheduleWidget events={events} />

--- a/src/pages/academic-calendar/index.tsx
+++ b/src/pages/academic-calendar/index.tsx
@@ -105,10 +105,7 @@ export default function AcademicCalendar() {
               events={events}
               onYearChange={setCurrentYear}
               onMonthChange={setCurrentMonth}
-              onDateSelect={(date) => {
-                console.log(date);
-                setSelectedDate(date);
-              }}
+              onDateSelect={setSelectedDate}
             />
           </div>
           <div>


### PR DESCRIPTION
## 주요 변경 사항

- 학사일정 모바일 페이지를 추가했습니다
- 이제 캘린더에서 특정 날짜를 선택할 수 있습니다
- 오늘 날짜에 해당되는 이벤트가 캘린더 하단에 표시됩니다
- 이번 달에 해당되는 이벤트가 캘린더 하단에 표시됩니다
- 선택한 날짜가 캘린더에 highlight 되어 표시됩니다

## 스크린샷

![horizontal_combined](https://github.com/user-attachments/assets/6edf2aaf-f6fc-4ee4-8549-4013be48ec64)
