### PR TITLE
<Feat> 명대뉴스 쿼리스트링 기반 상태로 리팩토링 및 페이지네이션 버그 수정 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,86 +1,195 @@
-# MJS-FRONT
+## 우리는 이런 서비스를 만들었어요
 
-## Installation
+> **공지사항 검색이 불편하신 적 없으신가요?**  
+> 매번 각각의 사이트를 검색하시지 않았나요?  
+> 졸업생들의 취업 정보와 커뮤니케이션이 필요하지 않나요?  
+> 학과 관련 공지를 인스타에서 찾기 불편하지 않으셨나요?
 
-1. 패키지 설치
+### 🎓 **MJS**는 **명지대학교 학생들을 위한 통합 검색 플랫폼**이에요
 
-```bash
-npm install
-```
+**MJS 하나로**, 명지대의 모든 소식과 자료를 빠르게 확인하여 정보 접근성을 높이고, 캠퍼스 내 정보 격차를 줄이는 것이 우리의 목표입니다. **MJS**는 재학생과 교직원이 매일 마주하는 **공지사항, 학사일정, 명대신문, 방송국, 식단, 날씨, 학과 일정·정보, 학교 트렌드, 졸업생 정보** 등을 **한 곳에서 통합 검색**하고 **학생들끼리 교류**할 수 있는 프로젝트입니다.
 
-2. TypeScript 버전 설정
+> 🔥 **MJS 하나면, 명지대의 모든 소식과 자료를 빠르게 확인할 수 있어요.**  
+> 정보 접근성을 높이고, 캠퍼스 내 정보 격차를 줄이는 게 우리의 목표예요.
 
-```
-추가 예정 입니다
-```
+---
 
-3. Run Dev server
+## 👥 Contributors
 
-```bash
-npm run dev
-```
+<table>
+  <tr>
+    <td align="center">
+      <a href="https://github.com/ChoiTheCreator">
+        <img src="https://github.com/ChoiTheCreator.png" width="100px" alt="hyunbin1"/><br/>
+        <sub><b>최원빈</b></sub>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/wooooooooook">
+        <img src="https://github.com/wooooooooook.png" width="100px" alt="wooooooooook"/><br/>
+        <sub><b>박재욱</b></sub>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://github.com/yuraup">
+        <img src="https://github.com/yuraup.png" width="100px" alt="miink0"/><br/>
+        <sub><b>이유라</b></sub>
+      </a>
+    </td>
+  </tr>
+</table>
 
-## 깃 전략
+---
 
-### 폴더 구조
+## 🔍 주요 기능 안내
 
-```
-추가 예정 입니다
-.
-├── eslint.config.js
-├── index.html
-├── package-lock.json
-├── package.json
-├── public
-│   └── vite.svg
-├── README.md
-├── src
-│   ├── App.css
-│   ├── App.tsx
-│   ├── assets
-│   │   └── react.svg
-│   ├── index.css
-│   ├── main.tsx
-│   └── vite-env.d.ts
-├── tsconfig.app.json
-├── tsconfig.json
-├── tsconfig.node.json
-└── vite.config.ts
-```
+> 현재 1–4번까지는 개발이 완료되었고, 5번은 아직 기획 중입니다.
 
-### 브랜치 분류
+### 1. 🏠 학생 생활 포털 기능
 
-```
-main: 운영용
-develop: 개발용
-feat/{제목}: 기능 추가
-fix/{제목}: 버그 수정
-refactor/{제목}: 리팩토링
-docs/{제목}: 문서 수정
-```
+- **메인페이지**  
+  MJS의 모든 기능에 빠르게 접근할 수 있는 포털로, 사용자의 주요 활동과 공지를 한눈에 확인할 수 있도록 구성되어 있습니다.
+- **자유게시판(커뮤니티)**  
+  학생 간 소통 공간으로, 질문·정보 공유·일상 이야기 등 다양한 주제를 자유롭게 나눌 수 있습니다.
+- **댓글 및 좋아요**  
+  게시글과 댓글에 의견을 표현해 참여와 소통을 활성화합니다.
+- **확성기**  
+  여러 사용자에게 중요한 소식을 빠르게 전달할 수 있는 공지 전용 커뮤니케이션 기능입니다.
+- **마이페이지**  
+  나의 활동 기록, 북마크, 설정 등을 관리할 수 있는 개인 맞춤형 공간입니다.
 
-- 제목은 케밥케이스 사용
+### 2. 📅 학교 생활 정보 기능
 
-### 커밋 메시지 컨벤션
+- **오늘의 학사 일정**  
+  오늘 진행되는 학사 일정을 요약 제공해 필요한 정보를 놓치지 않도록 도와드립니다.
+- **학사일정**  
+  연간 학사 일정을 월별로 정리해 쉽게 검색·확인할 수 있습니다.
+- **학과 일정**  
+  각 학과 학생회가 제공하는 일정·행사·회의 정보를 종합 안내합니다.
+- **공지사항** _(일반 / 학사 / 장학·학자금 / 진로·취업·창업 / 학생활동 / 학칙개정)_  
+  교내 부서·학과·기관 공지사항을 자동 수집해 카테고리별로 깔끔하게 정리합니다.
+- **학교 실시간 날씨(서대문구)**  
+  캠퍼스 위치 지역의 실시간 날씨를 제공해 외출이나 수업 준비에 도움을 줍니다.
+- **식단 안내**  
+  교내 식당의 메뉴와 운영 시간을 매일 업데이트합니다.
 
-```
-<{분류}> {제목}
+### 3. 🎓 학과별 정보·운영 기능
 
-- {내용1}
-- {내용2}
-```
+- **학과별 정보성 서비스**  
+  전공 팁, 교수님 스타일, 수강 신청 전략 등을 학생회에서 직접 운영합니다.
+- **학과별 서비스 어드민**  
+  학회 구성원이 일정·정보 게시를 관리할 수 있는 전용 관리자 기능입니다.
 
-- 내용은 필요한 경우에 작성
-- `분류`는 아래 [태스크 분류](#태스크-분류) 참고
+### 4. 🔎 검색 및 탐색 기능
 
-#### 태스크 분류
+- **통합 검색**  
+  공지사항, 게시글, 학사일정, 뉴스 등 다양한 정보를 키워드 기반으로 빠르게 탐색합니다.
+- **검색 결과 페이지**  
+  콘텐츠 유형별로 결과를 분류해 원하는 정보를 더욱 쉽게 찾을 수 있습니다.
+- **실시간 검색 순위**  
+  현재 가장 많이 검색되는 키워드를 집계해 캠퍼스 관심사를 파악할 수 있습니다.
 
-```
-Feat: 새로운 기능 추가
-Fix: 버그 수정
-Docs: 문서 수정
-Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
-Refactor: 코드 리펙토링
-Test: 테스트 코드, 리펙토링 테스트 코드 추가
-Chore: 빌드 업무 수정, 패키지 매니저 수정 등
-```
+### 5. 💼 진로 및 커리어 연계 서비스 _(기획 중)_
+
+- **취업정보**  
+  채용·공모전·진로 자료를 모아 제공해 체계적인 취업 준비를 돕습니다.
+- **졸업 멘토관**  
+  취업 후기, 실무 경험, 인터뷰 팁 등 졸업생의 생생한 조언을 제공합니다.
+
+## 메인 페이지(미리보기)
+
+<div align="center">
+  <img src="https://github.com/user-attachments/assets/25b56314-cb27-45b3-9d2f-a620877cd996" width="358" alt="MJS 메인 화면 프리뷰"/>
+</div>
+
+## 🗓️ 앞으로의 계획
+
+- **멘토관**  
+  일자리센터 멘토 등록 후 일정에 맞춘 예약 시스템 구축(후기·가격 포함).
+- **취업 가이드**  
+  일자리센터의 성공 사례 데이터를 기반으로 13개 직무 가이드 공개 예정.
+
+## 🤝 MJS가 드리고 싶은 약속
+
+> 저희는 **학생의 목소리를 가장 우선**으로 생각합니다.  
+> 작고 불편한 점도 놓치지 않고, 꾸준히 개선해 나가겠습니다.  
+> 여러분의 **학교생활이 조금 더 편하고 의미 있게** 바뀔 수 있도록 함께하겠습니다.
+
+## 🚀 핵심 기술 스택
+
+### ⚙️ Language & Framework
+
+<table>
+  <tr>
+    <td><img src="https://img.shields.io/badge/Java-17-007396?style=flat&logo=java&logoColor=white" height="20"/></td>
+    <td><b>Java 17</b><br/>백엔드 전반을 구성하는 주력 언어</td>
+  </tr>
+  <tr>
+    <td><img src="https://img.shields.io/badge/Spring_Boot-2.7.x-6DB33F?style=flat&logo=spring-boot&logoColor=white" height="20"/></td>
+    <td><b>Spring Boot</b><br/>REST API 및 비즈니스 로직 구현</td>
+  </tr>
+  <tr>
+    <td><img src="https://img.shields.io/badge/Spring_Security-Auth-6DB33F?style=flat&logo=spring-security&logoColor=white" height="20"/></td>
+    <td><b>Spring Security</b><br/>JWT 기반 인증·인가 처리</td>
+  </tr>
+  <tr>
+    <td><img src="https://img.shields.io/badge/JPA-Hibernate-6DB33F?style=flat&logo=hibernate&logoColor=white" height="20"/></td>
+    <td><b>JPA (Hibernate)</b><br/>ORM 기반 객체–관계 매핑</td>
+  </tr>
+</table>
+
+### 🗄️ Database
+
+<table>
+  <tr>
+    <td><img src="https://img.shields.io/badge/PostgreSQL-17-4169E1?style=flat&logo=postgresql&logoColor=white" height="20"/></td>
+    <td><b>PostgreSQL 17</b><br/>관계형 데이터베이스, RDS와 연동</td>
+  </tr>
+</table>
+
+### ☁️ Cloud & Infra (AWS)
+
+<table>
+  <tr>
+    <td><img src="https://img.shields.io/badge/EC2-t3.medium-FF9900?style=flat&logo=amazon-ec2&logoColor=white" height="20"/></td>
+    <td><b>AWS EC2</b><br/>Spring 서버가 배포된 인스턴스 (30 GiB EBS)</td>
+  </tr>
+  <tr>
+    <td><img src="https://img.shields.io/badge/S3-Static_Storage-569A31?style=flat&logo=amazons3&logoColor=white" height="20"/></td>
+    <td><b>AWS S3</b><br/>이미지 및 정적 자산 저장소</td>
+  </tr>
+  <tr>
+    <td><img src="https://img.shields.io/badge/CloudFront-CDN-232F3E?style=flat&logo=amazonaws&logoColor=white" height="20"/></td>
+    <td><b>AWS CloudFront</b><br/>정적 파일 전송 최적화를 위한 CDN</td>
+  </tr>
+</table>
+
+### 🐳 DevOps & Deployment
+
+<table>
+  <tr>
+    <td><img src="https://img.shields.io/badge/Docker-Container-2496ED?style=flat&logo=docker&logoColor=white" height="20"/></td>
+    <td><b>Docker</b><br/>백엔드 환경 컨테이너화 및 배포 자동화</td>
+  </tr>
+  <tr>
+    <td><img src="https://img.shields.io/badge/GitHub_Actions-CI/CD-2088FF?style=flat&logo=githubactions&logoColor=white" height="20"/></td>
+    <td><b>GitHub Actions</b><br/>CI/CD 자동화 파이프라인 구축</td>
+  </tr>
+</table>
+
+### 🧰 Tools & Collaboration
+
+<table>
+  <tr>
+    <td><img src="https://img.shields.io/badge/IntelliJ_IDEA-IDE-000000?style=flat&logo=intellijidea&logoColor=white" height="20"/></td>
+    <td><b>IntelliJ IDEA</b><br/>주 개발 IDE</td>
+  </tr>
+  <tr>
+    <td><img src="https://img.shields.io/badge/Postman-API_Test-FF6C37?style=flat&logo=postman&logoColor=white" height="20"/></td>
+    <td><b>Postman</b><br/>REST API 테스트 및 문서화</td>
+  </tr>
+  <tr>
+    <td><img src="https://img.shields.io/badge/Discord-Community-5865F2?style=flat&logo=discord&logoColor=white" height="20"/></td>
+    <td><b>Discord</b><br/>실시간 협업 및 커뮤니케이션</td>
+  </tr>
+</table>

--- a/src/pages/news/index.tsx
+++ b/src/pages/news/index.tsx
@@ -17,8 +17,9 @@ const DESKTOP_ITEMS_PER_PAGE = 8;
 const News = () => {
   /**
    * search parameter를 이용해서 검색 키워드 초기값을 불러옵니다
+   * setter 를 추가하여, 카테고리가 바뀌면 url에 쿼리가 찍히도록 합니다.
    */
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const keyword = searchParams.get('keyword');
   const [initialContent, setInitialContent] = useState('');
 
@@ -33,7 +34,7 @@ const News = () => {
     });
 
     if (entry) {
-      const key = entry[0];
+      const key = entry[0]; //한국어 탭 이름
       return key;
     }
     return '전체';
@@ -123,6 +124,14 @@ const News = () => {
           onChange={(category) => {
             setSelectedCategory(category);
             setPage(0);
+
+            const nextParams = new URLSearchParams(searchParams);
+            const serverCategory = NewsCategory[category]; //서버 enum 값으로
+
+            nextParams.set('category', serverCategory ?? 'ALL');
+            nextParams.set('page', '0');
+
+            setSearchParams(nextParams);
           }}
         />
       </div>
@@ -141,7 +150,16 @@ const News = () => {
           </div>
         )}
       </div>
-      <Pagination page={page} totalPages={totalPages} onChange={setPage} />
+      <Pagination
+        page={page}
+        totalPages={totalPages}
+        onChange={(page) => {
+          setPage(page);
+          const nextParams = new URLSearchParams(searchParams);
+          nextParams.set('page', page.toString());
+          setSearchParams(nextParams);
+        }}
+      />
     </div>
   );
 };

--- a/src/pages/news/index.tsx
+++ b/src/pages/news/index.tsx
@@ -23,6 +23,28 @@ const News = () => {
   const [initialContent, setInitialContent] = useState('');
 
   /**
+   * 서버에서 내려온 카테고리 값을 탭 이름(한글)으로 변환합니다.
+   */
+  const translateCategory = (serverValue: string): string => {
+    const entries = Object.entries(NewsCategory);
+    const entry = entries.find((entryItem) => {
+      const value = entryItem[1];
+      return value === serverValue;
+    });
+
+    if (entry) {
+      const key = entry[0];
+      return key;
+    }
+    return '전체';
+  };
+
+  const categoryParam = searchParams.get('category') ?? 'ALL';
+  const initialSelectedCategory = translateCategory(categoryParam);
+  const pageParam = Number(searchParams.get('page') ?? '1');
+  const initialPage = pageParam > 0 ? pageParam - 1 : 0;
+
+  /**
    * 주소에 search parameter 값이 있으면 검색바에 반영합니다
    */
   useEffect(() => {
@@ -37,8 +59,8 @@ const News = () => {
     })();
   }, [keyword]);
 
-  const [page, setPage] = useState(0);
-  const [selectedCategory, setSelectedCategory] = useState('전체');
+  const [page, setPage] = useState(initialPage);
+  const [selectedCategory, setSelectedCategory] = useState(initialSelectedCategory);
   const [newsList, setNewsList] = useState<NewsInfo[]>([]);
   const [totalPages, setTotalPages] = useState(1);
   const [isError, setIsError] = useState(false);
@@ -89,7 +111,7 @@ const News = () => {
   if (isError) return <GlobalErrorPage />;
 
   return (
-    <div className='flex-1 p-4 md:p-8 flex flex-col gap-4 md:gap-6'>
+    <div className='flex flex-1 flex-col gap-4 p-4 md:gap-6 md:p-8'>
       <Link to='/news'>
         <p className='text-blue-35 text-heading02 md:text-heading01'>명대신문</p>
       </Link>
@@ -104,8 +126,8 @@ const News = () => {
           }}
         />
       </div>
-      <div className='flex-1 flex flex-col'>
-        <div className='grid grid-cols-1 gap-4 md:gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'>
+      <div className='flex flex-1 flex-col'>
+        <div className='grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-6 lg:grid-cols-3 xl:grid-cols-4'>
           {newsList.map((news, index) => (
             <NewsCard key={index} news={news} />
           ))}
@@ -114,7 +136,7 @@ const News = () => {
          * 키워드를 입력했는데 검색 결과가 없는 경우
          */}
         {keyword && newsList.length === 0 && (
-          <div className='flex-1 text-center content-center'>
+          <div className='flex-1 content-center text-center'>
             <p className='text-title02'>검색 결과가 없습니다</p>
           </div>
         )}

--- a/src/pages/news/index.tsx
+++ b/src/pages/news/index.tsx
@@ -129,7 +129,7 @@ const News = () => {
             const serverCategory = NewsCategory[category]; //서버 enum 값으로
 
             nextParams.set('category', serverCategory ?? 'ALL');
-            nextParams.set('page', '0');
+            nextParams.set('page', '1');
 
             setSearchParams(nextParams);
           }}
@@ -156,7 +156,8 @@ const News = () => {
         onChange={(page) => {
           setPage(page);
           const nextParams = new URLSearchParams(searchParams);
-          nextParams.set('page', page.toString());
+          const appPage = page + 1;
+          nextParams.set('page', appPage.toString());
           setSearchParams(nextParams);
         }}
       />


### PR DESCRIPTION
## Summary
- /news 페이지의 카테고리, 페이지네이션, 검색 상태를 URL 쿼리스트링과 동기화했습니다.
- 0 페이지부터 시작하던 페이지네이션 기준을 서버/사용자 기준(1 페이지)과 맞추도록 수정했습니다.

## Before

- /news 진입 시 URL은 항상 `/news`로 고정되어 있었고, 내부 state만 변경
- 새로고침 시:
  - 선택된 카테고리/페이지 정보가 초기화
- 특정 상태를 공유하거나 북마크할 수 없음
  - `/news?category=REPORT&page=2`와 같은 딥링크 지원 X
- 페이지네이션은 내부적으로 0 페이지부터 시작했으나,
  URL/서버와 기준이 맞지 않아 혼동 가능성이 있었음

## After

- /news 상태가 URL 쿼리스트링과 동기화됨
  - 예: `/news?category=REPORT&page=2`, `/news?keyword=장학&page=1`
- 새로고침/직접 접속 시에도 동일한 카테고리/페이지/검색 상태 복원
- 뒤로가기/앞으로가기 사용 시, 이전 탭/페이지 상태로 자연스럽게 이동
- 페이지네이션 기준(0 기반 vs 1 기반)이 URL/서버/사용자 관점에서 일관되게 정리됨

또한 README 꾸며봤습니다.