### PR TITLE
<Fix> footer 약관/개인정보 링크 수정 및 검색 결과 탭 순서 변경

### DIFF
--- a/src/components/organisms/Footer/index.tsx
+++ b/src/components/organisms/Footer/index.tsx
@@ -53,14 +53,14 @@ export default function Footer() {
 
       <div className='text-caption02 text-grey-40 flex items-center gap-4 py-1'>
         <a
-          href='https://www.notion.so/31422ef5d21e8094a29cea25cd2aa4b7'
+          href='https://verbena-ixia-597.notion.site/Thingo-33e22ef5d21e80b08328edd8519b0b4e?source=copy_link'
           target='_blank'
           rel='noopener noreferrer'
         >
           이용약관
         </a>
         <a
-          href='https://www.notion.so/31422ef5d21e800cb597ee4e57f4ffab'
+          href='https://verbena-ixia-597.notion.site/Thingo-33e22ef5d21e807d9738dc14def5de24?source=copy_link'
           target='_blank'
           rel='noopener noreferrer'
         >

--- a/src/pages/search/SearchDetailOverlay.tsx
+++ b/src/pages/search/SearchDetailOverlay.tsx
@@ -246,9 +246,9 @@ export default function SearchDetail() {
           <ScrollableTap
             tabs={{
               ALL: 'ALL',
+              게시판: '게시판',
               공지사항: '공지사항',
               학사일정: '학사일정',
-              게시판: '게시판',
               명대신문: '명대신문',
               명대뉴스: '명대뉴스',
             }}


### PR DESCRIPTION
## 작업 배경
- footer의 이용약관/개인정보 처리방침 링크가 접근 권한이 필요한 페이지로 연결되고 있어, 공개 노션 링크로 교체가 필요했습니다.
- 검색결과/검색결과없음 화면 상단 탭 순서를 정책에 맞게 조정해야 했습니다.

## 변경 사항
1. Footer 링크 수정
- 이용약관 URL 변경
- 개인정보 처리방침 URL 변경

2. 검색 상세 상단 탭 순서 변경
- 기존: ALL-공지사항-학사일정-게시판-명대신문-명대뉴스
- 변경: ALL-게시판-공지사항-학사일정-명대신문-명대뉴스


