### PR TITLE
<Refactor> TanStack Query 리팩토링: 검색/메인/학과 페이지 중복 API 호출 제거 및 캐시 정책 표준화

### DIFF
--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -86,9 +86,10 @@ export type Category =
  * @param keyword 검색어를 입력하세요.
  * @returns 자동완성 키워드 배열을 return 합니다.
  */
-export const getSearchWordcompletion = async (keyword: string) => {
+export const getSearchWordcompletion = async (keyword: string, signal?: AbortSignal) => {
   const res = await apiClient.get<ApiResponse<string[]>>('/search/suggest', {
     params: { keyword },
+    signal,
   });
   return res.data.data;
 };

--- a/src/components/atoms/SearchBar/index.tsx
+++ b/src/components/atoms/SearchBar/index.tsx
@@ -6,34 +6,19 @@ import { twMerge } from 'tailwind-merge';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { GoArrowUpRight } from 'react-icons/go';
 import { useDebounce } from '@/hooks/useDebounce';
-import { getSearchWordcompletion } from '@/api/search';
 import { addRecentKeyword } from '@/utils/recentSearch';
 import { useAuthStore } from '@/store/useAuthStore';
-
 import { useSearchTracking } from '@/hooks/gtm/useSearchTracking';
+import { useSearchSuggestQuery } from '@/hooks/queries/useSearchQueries';
 
 interface SearchBarProps {
-  /**
-   * domain을 설정하면, 검색 수행 시 해당 domain에 맞는 페이지로 이동됩니다
-   */
   domain?: 'search' | 'notice' | 'news' | 'board' | 'broadcast';
-
-  /**
-   * initialContent를 설정하면 검색바가 렌더링될 때 해당 content가 입력된 상태로 렌더링됩니다
-   */
   initialContent?: string;
-
   className?: string;
   iconClassName?: string;
   searchSource?: string;
 }
 
-/**
- * 검색바 컴포넌트
- * @param domain 검색을 수행할 domain을 입력하세요. 검색 수행 시 해당 domain 페이지에서 검색을 수행합니다. 기본값은 search 이고, 기본값일 경우 검색 수행 시 통합검색 페이지로 이동됩니다.
- * @param initialContent 검색바가 렌더링될 때 initialContent가 입력된 상태로 렌더링됩니다
- * @param className 스타일을 입력하세요
- */
 export default function SearchBar({
   domain = 'search',
   initialContent,
@@ -47,10 +32,12 @@ export default function SearchBar({
   const user = useAuthStore((state) => state.user);
   const recentSearchScope = user?.uuid ?? undefined;
   const [value, setValue] = useState('');
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const prevLengthRef = useRef(0);
+  const searchBarRef = useRef<HTMLDivElement>(null);
 
   const { trackSearchSubmit } = useSearchTracking();
 
-  /** 통합검색(domain=search)일 때 기존 쿼리(tab 등) 유지 */
   const getSearchQuery = (keyword: string) => {
     if (domain !== 'search' || !keyword.trim())
       return `?keyword=${encodeURIComponent(keyword.trim())}`;
@@ -60,57 +47,46 @@ export default function SearchBar({
     if (tab) next.set('tab', tab);
     return `?${next.toString()}`;
   };
-  const [suggestedKeywords, setSuggestedKeywords] = useState<string[]>([]);
-  const initialized = useRef(true);
-  const prevLengthRef = useRef(0);
-  const searchBarRef = useRef<HTMLDivElement>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
 
-  /**
-   * 검색어 초기값을 받을 경우
-   */
   useEffect(() => {
     if (initialContent) {
-      initialized.current = false;
       setValue(initialContent);
-      setSuggestedKeywords([]);
+      setShowSuggestions(false);
     }
   }, [initialContent]);
 
-  /**
-   * 검색어 자동완성
-   * `useDebounce`는 검색어 입력 후 0.1초 내에 키보드를 다시 입력하는 경우 검색어 자동완성을 수행하지 않도록 합니다 (트래픽 절약)
-   */
+  // 디바운스된 값으로 자동완성 쿼리 실행 (signal 자동 전달로 실제 HTTP 취소)
   const debounced = useDebounce(value, 50);
+  const { data: suggestedKeywords = [] } = useSearchSuggestQuery(debounced);
+
+  // 글자가 줄어들거나 비워지면 자동완성 숨기기
   useEffect(() => {
-    if (!debounced.trim()) return;
-    if (!initialized.current) {
-      initialized.current = true;
-      return;
+    if (value.length === 0 || value.length < prevLengthRef.current) {
+      setShowSuggestions(false);
+    } else if (value.length > 0) {
+      setShowSuggestions(true);
     }
+    prevLengthRef.current = value.length;
+  }, [value]);
 
-    abortControllerRef.current?.abort();
+  // 새 제안이 오면 표시 (단, 비어있으면 숨기기)
+  useEffect(() => {
+    if (suggestedKeywords.length === 0) {
+      setShowSuggestions(false);
+    }
+  }, [suggestedKeywords]);
 
-    const controller = new AbortController();
-    abortControllerRef.current = controller;
-
-    (async () => {
-      try {
-        const res = await getSearchWordcompletion(debounced.trim());
-        if (!controller.signal.aborted) {
-          if (res.length !== 0) setSuggestedKeywords(res);
-        }
-      } catch {
-        // 에러는 상위에서 처리 (abort된 경우 무시)
-        // 자동완성 실패는 조용히 처리
+  // 외부 클릭 시 자동완성 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (searchBarRef.current && !searchBarRef.current.contains(event.target as Node)) {
+        setShowSuggestions(false);
       }
-    })();
-  }, [debounced]);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
 
-  /**
-   * 자동완성 키워드 아이템 클릭
-   * 현재 경로와 클릭한 키워드의 목적지 경로가 같으면 화면을 새로고침
-   */
   const handleKeywordClick = (keyword: string) => {
     const trimmed = keyword.trim();
     if (!trimmed) return;
@@ -124,6 +100,7 @@ export default function SearchBar({
 
     addRecentKeyword(trimmed, undefined, recentSearchScope);
     const search = getSearchQuery(trimmed);
+    setShowSuggestions(false);
 
     if (location.pathname === `/${domain}` && location.search === search) {
       window.location.reload();
@@ -132,54 +109,8 @@ export default function SearchBar({
     }
   };
 
-  /**
-   * 검색어를 지울 경우 검색어 자동완성 창 자동 닫기
-   */
-  useEffect(() => {
-    // 완전히 비워졌을 때는 항상 닫기
-    if (value.length === 0) {
-      setSuggestedKeywords([]);
-    }
-
-    // 백스페이스 등으로 글자가 줄어들면 추천을 즉시 닫아 UX를 자연스럽게 유지
-    if (value.length < prevLengthRef.current) {
-      setSuggestedKeywords([]);
-    }
-
-    prevLengthRef.current = value.length;
-  }, [value]);
-
-  /**
-   * 검색창 외부 클릭 시 자동완성 창 닫기
-   */
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (searchBarRef.current && !searchBarRef.current.contains(event.target as Node)) {
-        handleCloseBox();
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [searchBarRef]);
-
-  /**
-   * 검색어 자동완성 창 닫기 버튼 핸들러
-   */
-  const handleCloseBox = () => {
-    setSuggestedKeywords([]);
-  };
-
-  /**
-   * 검색 수행 핸들러 (엔터 클릭 시)
-   */
   const handleSubmitSearch = () => {
-    abortControllerRef.current?.abort();
-    setSuggestedKeywords([]);
-
+    setShowSuggestions(false);
     const trimmed = value.trim();
 
     if (trimmed) {
@@ -189,19 +120,14 @@ export default function SearchBar({
         search_source: searchSource,
         search_action: 'submit',
       });
-
       addRecentKeyword(trimmed, undefined, recentSearchScope);
-      navigate({
-        pathname: `/${domain}`,
-        search: getSearchQuery(trimmed),
-      });
+      navigate({ pathname: `/${domain}`, search: getSearchQuery(trimmed) });
     } else {
-      navigate({
-        pathname: `/${domain}`,
-      });
+      navigate({ pathname: `/${domain}` });
     }
-    setSuggestedKeywords([]);
   };
+
+  const visibleSuggestions = showSuggestions ? suggestedKeywords : [];
 
   return (
     <div className='relative' ref={searchBarRef}>
@@ -210,7 +136,7 @@ export default function SearchBar({
         className={twMerge(
           clsx(
             'border-blue-35 flex items-center gap-3 border-2 bg-white px-5 py-3 transition-all md:shadow-sm md:hover:shadow-md',
-            suggestedKeywords.length === 0 ? 'rounded-full' : 'rounded-t-2xl border-b-0',
+            visibleSuggestions.length === 0 ? 'rounded-full' : 'rounded-t-2xl border-b-0',
           ),
           className,
         )}
@@ -230,9 +156,7 @@ export default function SearchBar({
             className='text-body03 md:text-body01 placeholder-grey-20 min-w-0 flex-1 shrink bg-transparent text-black outline-none'
             placeholder={'검색어를 입력하세요'}
             value={value}
-            onChange={(e) => {
-              setValue(e.target.value);
-            }}
+            onChange={(e) => setValue(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 if (e.nativeEvent.isComposing) return;
@@ -252,16 +176,14 @@ export default function SearchBar({
       </div>
 
       {/* 키워드 자동완성 박스 */}
-      {suggestedKeywords.length !== 0 && (
+      {visibleSuggestions.length > 0 && (
         <div className='absolute top-full left-0 z-50 mt-1 w-full'>
           <div className='ring-blue-05 flex flex-col gap-1 rounded-2xl bg-white/95 shadow-lg ring-1 backdrop-blur-sm'>
             <div className='border-blue-05/40 flex max-h-80 flex-col overflow-y-auto border-b'>
-              {suggestedKeywords.map((item, index) => (
+              {visibleSuggestions.map((item, index) => (
                 <button
                   key={index}
-                  onClick={() => {
-                    handleKeywordClick(item);
-                  }}
+                  onClick={() => handleKeywordClick(item)}
                   className='text-body04 text-grey-90 hover:bg-blue-05/40 active:bg-blue-05/60 flex h-fit w-full items-center gap-3 px-4 py-2.5 text-left transition'
                 >
                   <span className='bg-blue-05 text-blue-35 flex h-7 w-7 items-center justify-center rounded-full text-xs'>
@@ -274,7 +196,7 @@ export default function SearchBar({
             </div>
             <a
               className='text-caption02 text-grey-40 w-fit self-end px-4 py-2 underline-offset-2 hover:underline'
-              onClick={handleCloseBox}
+              onClick={() => setShowSuggestions(false)}
             >
               닫기
             </a>

--- a/src/components/molecules/sections/board.tsx
+++ b/src/components/molecules/sections/board.tsx
@@ -1,20 +1,18 @@
-import { getBoards, type BoardItem, type Category } from '@/api/board';
+import type { Category } from '@/api/board';
 import { CardHeader } from '@/components/atoms/Card';
 import { formatToDotDate } from '@/utils/date';
-import { handleError } from '@/utils/error';
 import clsx from 'clsx';
-import { useEffect, useState } from 'react';
+import { useState, useEffect } from 'react';
 import Pagination from '@/components/molecules/common/Pagination';
 import { MdChevronRight } from 'react-icons/md';
 import { Link } from 'react-router-dom';
 import { createPortal } from 'react-dom';
 import { ChatBubbleIcon, HeartIcon } from '@/components/atoms/Icon';
 import { useHeaderStore } from '@/store/useHeaderStore';
+import { useBoardQuery } from '@/hooks/queries/useBoardQuery';
 
-// 카테고리 및 페이지 길이 조절
 const ITEM_COUNT = 10;
 
-// 카테고리·페이지 값을 세션 스토리지에 보관
 const BOARD_TAB_STORAGE_KEY = 'board-section-category';
 const BOARD_PAGE_STORAGE_KEY_PREFIX = 'board-section-page';
 
@@ -31,11 +29,9 @@ function getStoredPageForCategory(cat: 'NOTICE' | 'FREE'): number {
   return Number.isInteger(num) && num >= 0 ? num : 0;
 }
 
-// 메인페이지에 표시할 자유게시판 위젯 컴포넌트
 interface BoardSectionProps {
   showWriteButton?: boolean;
   all?: boolean;
-  /** 제공 시 더보기 클릭으로 호출(예: 슬라이드 게시판 탭으로 이동), 미제공 시 /board로 이동 */
   onSeeMoreClick?: () => void;
 }
 
@@ -48,11 +44,8 @@ export default function BoardSection({
   const setBoardCategory = useHeaderStore((s) => s.setBoardCategory);
 
   const [category, setCategory] = useState<'NOTICE' | 'FREE'>(getStoredCategory);
-  const [contents, setContents] = useState<BoardItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [isMounted, setIsMounted] = useState(false);
 
-  // 사이드바 등에서 정보/자유 게시판 클릭 시 지정된 탭으로 전환 후 초기화
   useEffect(() => {
     if (boardCategoryFromNav === 'NOTICE' || boardCategoryFromNav === 'FREE') {
       setCategory(boardCategoryFromNav);
@@ -64,42 +57,20 @@ export default function BoardSection({
     NOTICE: getStoredPageForCategory('NOTICE'),
     FREE: getStoredPageForCategory('FREE'),
   }));
-  const [totalPages, setTotalPages] = useState(0);
 
   const page = pageByCategory[category];
-  const setPage = (nextPage: number) =>
+  const setPage = (nextPage: number) => {
     setPageByCategory((prev) => ({ ...prev, [category]: nextPage }));
+    sessionStorage.setItem(`${BOARD_PAGE_STORAGE_KEY_PREFIX}-${category}`, String(nextPage));
+  };
 
-  useEffect(() => {
-    (async () => {
-      try {
-        setIsLoading(true);
-        const res = await getBoards({
-          page,
-          size: ITEM_COUNT,
-          communityCategory: category as Category,
-        });
-        setTotalPages(res.totalPages);
-        setContents(all ? res.content.slice(0, 5) : res.content);
-      } catch (e) {
-        handleError(e, '게시글을 불러오는 중 오류가 발생했습니다.', { showToast: false });
-      } finally {
-        setIsLoading(false);
-      }
-    })();
-  }, [category, page, all]);
+  const { data, isLoading } = useBoardQuery(category as Category, page, ITEM_COUNT);
+  const contents = all ? (data?.content?.slice(0, 5) ?? []) : (data?.content ?? []);
+  const totalPages = data?.totalPages ?? 0;
 
   useEffect(() => {
     sessionStorage.setItem(BOARD_TAB_STORAGE_KEY, category);
   }, [category]);
-
-  useEffect(() => {
-    sessionStorage.setItem(
-      `${BOARD_PAGE_STORAGE_KEY_PREFIX}-NOTICE`,
-      String(pageByCategory.NOTICE),
-    );
-    sessionStorage.setItem(`${BOARD_PAGE_STORAGE_KEY_PREFIX}-FREE`, String(pageByCategory.FREE));
-  }, [pageByCategory]);
 
   useEffect(() => {
     setIsMounted(true);
@@ -127,7 +98,6 @@ export default function BoardSection({
         </CardHeader>
       )}
 
-      {/* 탭 네비게이션 */}
       {!all && (
         <div className='bg-grey-02 my-0 flex items-center pt-[8px]'>
           <div className='flex flex-1 items-center overflow-hidden'>
@@ -157,69 +127,50 @@ export default function BoardSection({
         </div>
       )}
 
-      {/* 게시글 리스트 */}
       <div className='flex flex-col pt-4'>
-        {(() => {
-          return contents.map((content, index) => {
-            const isLast = index === contents.length - 1;
-
-            return (
-              <Link
-                key={content.uuid}
-                to={`/board/${content.uuid}`}
-                className='active:bg-blue-05 hover:bg-blue-05'
-              >
-                <div className='px-5 py-2'>
-                  {/* 제목 */}
-                  <div className='flex items-center'>
-                    {content.popular && (
-                      <div className='bg-blue-20 text-caption04 me-1 flex h-5 w-10 items-center justify-center rounded-full text-white'>
-                        HOT
-                      </div>
-                    )}
-                    <p className='text-body04 text-grey-80 line-clamp-1'>{content.title}</p>
-                  </div>
-
-                  {/* 본문 미리보기 */}
-                  <p className='text-body05 mt-1 line-clamp-2 text-black'>
-                    {content.previewContent}
-                  </p>
-
-                  <div className='mt-2 flex items-center justify-between'>
-                    {/* 좋아요 갯수 */}
-                    <div className='flex items-center'>
-                      <HeartIcon className='text-blue-10' filled={content.liked} />
-                      <span className='text-caption02 text-grey-40 ms-1'>{content.likeCount}</span>
-
-                      {/* 댓글 갯수 */}
-                      <ChatBubbleIcon className='text-blue-10 ms-2' />
-                      <span className='text-caption02 text-grey-40 ms-1'>
-                        {content.commentCount}
-                      </span>
+        {contents.map((content, index) => {
+          const isLast = index === contents.length - 1;
+          return (
+            <Link
+              key={content.uuid}
+              to={`/board/${content.uuid}`}
+              className='active:bg-blue-05 hover:bg-blue-05'
+            >
+              <div className='px-5 py-2'>
+                <div className='flex items-center'>
+                  {content.popular && (
+                    <div className='bg-blue-20 text-caption04 me-1 flex h-5 w-10 items-center justify-center rounded-full text-white'>
+                      HOT
                     </div>
-
-                    {/* 작성 날짜 (미공개 글은 publishedAt이 null일 수 있음) */}
-                    <span className='text-caption02 text-grey-40'>
-                      {content.publishedAt
-                        ? formatToDotDate(content.publishedAt)
-                        : formatToDotDate(content.createdAt)}
-                    </span>
-                  </div>
+                  )}
+                  <p className='text-body04 text-grey-80 line-clamp-1'>{content.title}</p>
                 </div>
-                {!isLast && <div className='bg-grey-02 h-px' />}
-              </Link>
-            );
-          });
-        })()}
+                <p className='text-body05 mt-1 line-clamp-2 text-black'>{content.previewContent}</p>
+                <div className='mt-2 flex items-center justify-between'>
+                  <div className='flex items-center'>
+                    <HeartIcon className='text-blue-10' filled={content.liked} />
+                    <span className='text-caption02 text-grey-40 ms-1'>{content.likeCount}</span>
+                    <ChatBubbleIcon className='text-blue-10 ms-2' />
+                    <span className='text-caption02 text-grey-40 ms-1'>{content.commentCount}</span>
+                  </div>
+                  <span className='text-caption02 text-grey-40'>
+                    {content.publishedAt
+                      ? formatToDotDate(content.publishedAt)
+                      : formatToDotDate(content.createdAt)}
+                  </span>
+                </div>
+              </div>
+              {!isLast && <div className='bg-grey-02 h-px' />}
+            </Link>
+          );
+        })}
 
-        {/* 예외처리 */}
         {!isLoading && contents.length === 0 && (
           <div className='flex flex-1 items-center justify-center py-10'>
             <span className='text-body05 text-grey-20'>등록된 게시글이 없습니다.</span>
           </div>
         )}
 
-        {/* 페이지네이션 */}
         {contents.length > 0 && !all && (
           <div className='pb-4'>
             <Pagination page={page} totalPages={totalPages} onChange={setPage} />
@@ -227,7 +178,6 @@ export default function BoardSection({
         )}
       </div>
 
-      {/* 글 작성 버튼 (Floating Action Button) */}
       {!all &&
         isMounted &&
         showWriteButton &&

--- a/src/components/molecules/sections/broadcast.tsx
+++ b/src/components/molecules/sections/broadcast.tsx
@@ -1,59 +1,33 @@
-import { fetchBroadcasts, type BroadcastItem } from '@/api/main/broadcast-api';
 import { CardHeader } from '@/components/atoms/Card';
 import { Skeleton } from '@/components/atoms/Skeleton';
 import { BROADCAST_PAGE_SIZE } from '@/constants/common';
 import { formatToLocalDate } from '@/utils';
-import { handleError } from '@/utils/error';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { IoMdPlay } from 'react-icons/io';
 import { MdChevronRight } from 'react-icons/md';
 import { Link } from 'react-router-dom';
 import Pagination from '../common/Pagination';
+import { useBroadcastQuery } from '@/hooks/queries/useBroadcastQuery';
 
 export default function BroadcastSection({
   all = false,
   onSeeMoreClick,
 }: {
   all?: boolean;
-  /** 제공 시 더보기 클릭으로 호출(예: 슬라이드 명대뉴스 탭으로 이동), 미제공 시 /broadcast로 이동 */
   onSeeMoreClick?: () => void;
 }) {
-  const [broadcasts, setBroadcasts] = useState<BroadcastItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [page, setPage] = useState(0);
-  const [totalPages, setTotalPages] = useState(0);
-
   const size = BROADCAST_PAGE_SIZE;
 
-  /**
-   * 명대방송 데이터 조회
-   */
-  useEffect(() => {
-    (async () => {
-      try {
-        setIsLoading(true);
-        // 클라이언트 측 가공 혹은 API 파라미터 연동 (현재는 전체 데이터 최신순 위주)
-        const data = await fetchBroadcasts(page, size);
-        const items = data.content as unknown as BroadcastItem[];
-        setTotalPages(data.totalPages);
+  const { data, isLoading } = useBroadcastQuery(page, size);
 
-        const toTS = (d?: string) => {
-          const t = d ? Date.parse(d) : NaN;
-          return Number.isNaN(t) ? 0 : t;
-        };
-
-        const sorted = [...items];
-        sorted.sort((a, b) => toTS(b.publishedAt) - toTS(a.publishedAt));
-
-        if (all) setBroadcasts(sorted.slice(0, 5));
-        else setBroadcasts(sorted);
-      } catch (err) {
-        handleError(err, '방송 정보를 불러오는 중 오류가 발생했습니다.', { showToast: false });
-      } finally {
-        setIsLoading(false);
-      }
-    })();
-  }, [page, size]);
+  const toTS = (d?: string) => {
+    const t = d ? Date.parse(d) : NaN;
+    return Number.isNaN(t) ? 0 : t;
+  };
+  const sorted = [...(data?.content ?? [])].sort((a, b) => toTS(b.publishedAt) - toTS(a.publishedAt));
+  const broadcasts = all ? sorted.slice(0, 5) : sorted;
+  const totalPages = data?.totalPages ?? 0;
 
   return (
     <section className='mb-4 flex flex-col bg-white'>
@@ -78,7 +52,6 @@ export default function BroadcastSection({
       )}
 
       <div className='flex flex-col'>
-        {/* 방송 리스트 컨텐츠 */}
         <div className='flex w-full flex-col gap-4 px-5 pt-4'>
           {isLoading &&
             [...Array(3)].map((_, index) => (
@@ -97,7 +70,6 @@ export default function BroadcastSection({
                 rel='noopener noreferrer'
                 className='border-grey-20 flex shrink-0 flex-col overflow-hidden rounded-xl border bg-white transition-transform'
               >
-                {/* 썸네일 영역 */}
                 <div className='relative h-[198px] w-full overflow-hidden bg-black'>
                   <img
                     src={item.thumbnailUrl || '/default-thumbnail.png'}
@@ -110,8 +82,6 @@ export default function BroadcastSection({
                     </div>
                   </div>
                 </div>
-
-                {/* 텍스트 정보 영역 */}
                 <div className='flex flex-col gap-1 px-4 py-3'>
                   <div className='flex flex-col'>
                     <h3 className='text-body02 line-clamp-2 font-semibold text-black'>
@@ -132,7 +102,6 @@ export default function BroadcastSection({
           )}
         </div>
 
-        {/* 페이지네이션 */}
         {!isLoading && broadcasts.length > 0 && !all && (
           <div className='pb-4'>
             <Pagination page={page} totalPages={totalPages} onChange={setPage} />

--- a/src/components/molecules/sections/news.tsx
+++ b/src/components/molecules/sections/news.tsx
@@ -1,17 +1,16 @@
-import { fetchNewsInfo } from '@/api/news';
 import { CardHeader } from '@/components/atoms/Card';
 import { Skeleton } from '@/components/atoms/Skeleton';
 import { ICON_SIZE_LG } from '@/constants/common';
 import { useResponsive } from '@/hooks/useResponse';
 import type { NewsInfo } from '@/types/news/newsInfo';
 import { formatToLocalDate } from '@/utils';
-import { handleError } from '@/utils/error';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { IoIosArrowForward } from 'react-icons/io';
 import { MdChevronRight } from 'react-icons/md';
 import { Link } from 'react-router-dom';
 import Pagination from '../common/Pagination';
 import { ChipTabs } from '@/components/atoms/Tabs';
+import { useNewsQuery } from '@/hooks/queries/useNewsQuery';
 
 const tabNameMap: Record<string, string> = {
   ALL: '전체',
@@ -24,45 +23,22 @@ export default function NewsSection({
   onSeeMoreClick,
 }: {
   all?: boolean;
-  /** 제공 시 더보기 클릭으로 호출(예: 슬라이드 명대신문 탭으로 이동), 미제공 시 /news로 이동 */
   onSeeMoreClick?: () => void;
 }) {
   const [categoryTab, setCategoryTab] = useState<string>('ALL');
-  const [fetchedNews, setFetchedNews] = useState<NewsInfo[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [page, setPage] = useState(0);
-  const [totalPages, setTotalPages] = useState(0);
   const { isDesktop } = useResponsive();
 
-  /**
-   * 뉴스 데이터 조회
-   */
-  useEffect(() => {
-    (async () => {
-      try {
-        setIsLoading(true);
-        const response = await fetchNewsInfo(categoryTab, page, isDesktop ? 5 : 10);
-        const items = response.data.content ?? [];
-        setTotalPages(response.data.totalPages);
+  const size = isDesktop ? 5 : 10;
+  const { data, isLoading } = useNewsQuery(categoryTab, page, size);
 
-        // 정렬 로직 (클라이언트 측 혹은 API 연동 확인 필요 - 현재 API 파라미터에 sortBy가 없으므로 클라이언트 정렬)
-        const toTS = (d?: string) => {
-          const t = d ? Date.parse(d) : NaN;
-          return Number.isNaN(t) ? 0 : t;
-        };
-
-        const sorted = [...items];
-        sorted.sort((a, b) => toTS(b.date) - toTS(a.date));
-
-        if (all) setFetchedNews(sorted.slice(0, 5));
-        else setFetchedNews(sorted);
-      } catch (e) {
-        handleError(e, '뉴스를 불러오는 중 오류가 발생했습니다.', { showToast: false });
-      } finally {
-        setIsLoading(false);
-      }
-    })();
-  }, [categoryTab, page, isDesktop]);
+  const toTS = (d?: string) => {
+    const t = d ? Date.parse(d) : NaN;
+    return Number.isNaN(t) ? 0 : t;
+  };
+  const sorted = [...(data?.data?.content ?? [])].sort((a, b) => toTS(b.date) - toTS(a.date));
+  const fetchedNews: NewsInfo[] = all ? sorted.slice(0, 5) : sorted;
+  const totalPages = data?.data?.totalPages ?? 0;
 
   return (
     <section className='mb-4 flex flex-col bg-white'>
@@ -85,7 +61,6 @@ export default function NewsSection({
           )}
         </CardHeader>
       )}
-      {/* 데스크탑 헤더 */}
       {isDesktop && (
         <div className='mb-3 flex items-center justify-between px-3'>
           <h2 className='text-heading02 text-mju-primary'>명대신문</h2>
@@ -106,13 +81,11 @@ export default function NewsSection({
         </div>
       )}
 
-      {/* 가로 스크롤 칩 메뉴 */}
       <div className='no-scrollbar swiper-no-swiping flex items-center gap-2 overflow-x-auto px-5 py-4'>
         <ChipTabs tabs={tabNameMap} currentTab={categoryTab} setCurrentTab={setCategoryTab} />
       </div>
 
       <div className='flex flex-col'>
-        {/* 뉴스 리스트 컨텐츠 */}
         <div className='border-grey-02 flex flex-col border-t'>
           {isLoading &&
             [...Array(5)].map((_, index) => (
@@ -130,7 +103,6 @@ export default function NewsSection({
                 rel='noopener noreferrer'
                 className='border-grey-02 hover:bg-blue-05 flex items-center gap-4 border-b px-5 py-4 transition-colors'
               >
-                {/* 썸네일 */}
                 <div className='border-grey-10 relative h-[103px] w-[110px] shrink-0 overflow-hidden rounded-[4px] border'>
                   <img
                     src={news.imageUrl?.trim() || '/default-thumbnail.png'}
@@ -141,8 +113,6 @@ export default function NewsSection({
                     }}
                   />
                 </div>
-
-                {/* 텍스트 정보 */}
                 <div className='flex flex-1 flex-col justify-between self-stretch py-1'>
                   <div className='flex flex-col gap-1'>
                     <h3 className='text-body02 line-clamp-1 font-semibold text-black'>
@@ -171,7 +141,6 @@ export default function NewsSection({
           )}
         </div>
 
-        {/* 페이지네이션 */}
         {!isLoading && fetchedNews.length > 0 && !all && (
           <div className='pb-4'>
             <Pagination page={page} totalPages={totalPages} onChange={setPage} />

--- a/src/components/molecules/sections/notice.tsx
+++ b/src/components/molecules/sections/notice.tsx
@@ -1,13 +1,12 @@
-import { fetchNotionInfo } from '@/api/main/notice-api';
 import { CardHeader } from '@/components/atoms/Card';
 import { ChipTabs } from '@/components/atoms/Tabs';
 import type { NoticeItem } from '@/types/notice/noticeInfo';
 import { formatToDotDate } from '@/utils/date';
-import { handleError } from '@/utils/error';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { MdChevronRight } from 'react-icons/md';
 import { Link } from 'react-router-dom';
 import Pagination from '../common/Pagination';
+import { useNoticeQuery } from '@/hooks/queries/useNoticeQuery';
 
 export const tabNameMap: Record<string, string> = {
   all: '전체',
@@ -28,15 +27,8 @@ const categoryNameMap: Record<string, string> = {
   rule: '학칙개정',
 };
 
-/**
- * 불러올 공지사항 데이터 갯수를 지정하세요
- */
 const CONTENT_LENGTH = 7;
 
-/**
- * 전용 공지사항 헤더
- * onSeeMoreClick이 있으면 더보기 클릭 시 해당 콜백 실행(예: 슬라이드 내 공지사항 탭으로 이동), 없으면 /notice 페이지로 이동
- */
 const NoticeSlideHeader = ({ onSeeMoreClick }: { onSeeMoreClick?: () => void }) => (
   <CardHeader className='px-1'>
     <h2 className='text-title03 px-3 font-bold text-black'>공지사항</h2>
@@ -57,12 +49,8 @@ const NoticeSlideHeader = ({ onSeeMoreClick }: { onSeeMoreClick?: () => void }) 
   </CardHeader>
 );
 
-/**
- * 슬라이드용 공지사항 아이템 컴포넌트
- */
 const NoticeSlideCard = ({ info }: { info: NoticeItem }) => {
   const displayDate = formatToDotDate(info.date);
-
   return (
     <a
       href={info.link}
@@ -83,39 +71,14 @@ export function NoticeSlideSection({
   onSeeMoreClick,
 }: {
   all?: boolean;
-  /** 제공 시 더보기(화살표) 클릭으로 호출되며, 미제공 시 /notice로 이동 */
   onSeeMoreClick?: () => void;
 }) {
   const [selectedTab, setSelectedTab] = useState('all');
-  const [selectedInfo, setSelectedInfo] = useState<NoticeItem[]>([]);
-  const [allDataCache, setAllDataCache] = useState<Record<string, NoticeItem[]>>({});
-  const recentYear = new Date().getFullYear();
-  const [isLoading, setIsLoading] = useState(true);
+  const { data, isLoading } = useNoticeQuery(selectedTab, 0, CONTENT_LENGTH);
 
-  useEffect(() => {
-    (async () => {
-      if (allDataCache[selectedTab]) {
-        setSelectedInfo(allDataCache[selectedTab]);
-        setIsLoading(false);
-      } else {
-        try {
-          setIsLoading(true);
-          const fetchedNoticeData = await fetchNotionInfo(selectedTab, 0, CONTENT_LENGTH);
-          if (all) setSelectedInfo(fetchedNoticeData.content.slice(0, 5));
-          else setSelectedInfo(fetchedNoticeData.content);
-          setAllDataCache((prevCache) => ({
-            ...prevCache,
-            [selectedTab]: all ? fetchedNoticeData.content.slice(0, 5) : fetchedNoticeData.content,
-          }));
-        } catch (e) {
-          handleError(e, '공지사항을 불러오는 중 오류가 발생했습니다.', { showToast: false });
-          setSelectedInfo([]);
-        } finally {
-          setIsLoading(false);
-        }
-      }
-    })();
-  }, [selectedTab, recentYear, allDataCache]);
+  const items = all
+    ? (data?.content?.slice(0, 5) ?? [])
+    : (data?.content ?? []);
 
   return (
     <section className='flex flex-col gap-3'>
@@ -127,7 +90,7 @@ export function NoticeSlideSection({
 
       <div className='flex flex-col pt-1'>
         {!isLoading &&
-          selectedInfo.map((info, i) => <NoticeSlideCard key={`${info.link}-${i}`} info={info} />)}
+          items.map((info, i) => <NoticeSlideCard key={`${info.link}-${i}`} info={info} />)}
       </div>
     </section>
   );
@@ -143,54 +106,33 @@ export default function NoticeSection() {
     if (!saved) return 'all';
     return Object.prototype.hasOwnProperty.call(tabNameMap, saved) ? saved : 'all';
   });
-  const [selectedInfo, setSelectedInfo] = useState<NoticeItem[]>([]);
-  const recentYear = new Date().getFullYear();
   const [page, setPage] = useState<number>(() => {
     if (typeof window === 'undefined') return 0;
     const saved = window.sessionStorage.getItem(SESSION_STORAGE_PAGE_KEY);
     const parsed = saved ? Number.parseInt(saved, 10) : 0;
     return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
   });
-  const [totalPages, setTotalPages] = useState<number>(0);
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    window.sessionStorage.setItem(SESSION_STORAGE_SELECTED_TAB_KEY, selectedTab);
-  }, [selectedTab]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    window.sessionStorage.setItem(SESSION_STORAGE_PAGE_KEY, String(page));
-  }, [page]);
+  const { data } = useNoticeQuery(selectedTab, page, 10, 'desc');
+  const selectedInfo = data?.content ?? [];
+  const totalPages = data?.totalPages ?? 0;
 
   const handleTabChange = (tab: unknown) => {
     const nextTab = String(tab);
     if (nextTab === selectedTab) {
-      if (page !== 0) {
-        setPage(0);
-      }
+      if (page !== 0) setPage(0);
       return;
     }
-
     setPage(0);
     setSelectedTab(nextTab);
+    window.sessionStorage.setItem(SESSION_STORAGE_SELECTED_TAB_KEY, nextTab);
   };
 
-  // 공지사항 데이터 조회
-  useEffect(() => {
-    (async () => {
-      try {
-        const fetchedNoticeData = await fetchNotionInfo(selectedTab, page, 10, 'desc');
-        setSelectedInfo(fetchedNoticeData.content);
-        setTotalPages(fetchedNoticeData.totalPages);
-      } catch (e) {
-        handleError(e, '공지사항을 불러오는 중 오류가 발생했습니다.', { showToast: false });
-        setSelectedInfo([]);
-      }
-    })();
-  }, [selectedTab, recentYear, page]);
+  const handlePageChange = (nextPage: number) => {
+    setPage(nextPage);
+    window.sessionStorage.setItem(SESSION_STORAGE_PAGE_KEY, String(nextPage));
+  };
 
-  // 공지사항 아이템 컴포넌트 (피그마 디자인 적용)
   const NoticeCard = ({ info }: { info: NoticeItem }) => (
     <a
       href={info.link}
@@ -218,10 +160,9 @@ export default function NoticeSection() {
         ))}
       </div>
 
-      {/* 페이지네이션 */}
       {selectedInfo.length > 0 && (
         <div className='mb-4'>
-          <Pagination page={page} totalPages={totalPages} onChange={setPage} />
+          <Pagination page={page} totalPages={totalPages} onChange={handlePageChange} />
         </div>
       )}
     </section>

--- a/src/components/organisms/Footer/index.tsx
+++ b/src/components/organisms/Footer/index.tsx
@@ -9,7 +9,7 @@ export default function Footer() {
         <div className='text-blue-10 flex items-center gap-3'>
           {/* 깃 아이콘 */}
           <a
-            href='https://github.com/NOVA-MJU/THINGO_BACKEND'
+            href='https://github.com/NOVA-MJU'
             target='_blank'
             rel='noopener noreferrer'
             aria-label='깃허브'

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -23,6 +23,11 @@ export const DEPARTMENT_NOTICE_STALE_TIME_MS = 5 * 60 * 1000;
 export const SEARCH_STALE_TIME_MS = 2 * 60 * 1000;
 export const SEARCH_SUGGEST_STALE_TIME_MS = 60 * 1000;
 export const AI_SUMMARY_STALE_TIME_MS = 10 * 60 * 1000;
+export const BROADCAST_SEARCH_STALE_TIME_MS = 2 * 60 * 1000;
+export const BOARD_DETAIL_STALE_TIME_MS = 2 * 60 * 1000;
+export const BOARD_COMMENTS_STALE_TIME_MS = 60 * 1000;
+export const MYPAGE_STALE_TIME_MS = 5 * 60 * 1000;
+export const HOT_KEYWORDS_STALE_TIME_MS = 60 * 1000;
 
 export const ICON_SIZE_SM = 12;
 export const ICON_SIZE_MD = 16;

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -13,6 +13,16 @@ export const CALENDAR_API_DEFAULT_SIZE = 100;
 export const SEARCH_API_DEFAULT_SIZE = 10;
 
 export const MENU_STALE_TIME_MS = 5 * 60 * 1000;
+export const NOTICE_STALE_TIME_MS = 5 * 60 * 1000;
+export const BOARD_STALE_TIME_MS = 3 * 60 * 1000;
+export const NEWS_STALE_TIME_MS = 5 * 60 * 1000;
+export const BROADCAST_STALE_TIME_MS = 5 * 60 * 1000;
+export const DEPARTMENT_INFO_STALE_TIME_MS = 10 * 60 * 1000;
+export const DEPARTMENT_SCHEDULE_STALE_TIME_MS = 10 * 60 * 1000;
+export const DEPARTMENT_NOTICE_STALE_TIME_MS = 5 * 60 * 1000;
+export const SEARCH_STALE_TIME_MS = 2 * 60 * 1000;
+export const SEARCH_SUGGEST_STALE_TIME_MS = 60 * 1000;
+export const AI_SUMMARY_STALE_TIME_MS = 10 * 60 * 1000;
 
 export const ICON_SIZE_SM = 12;
 export const ICON_SIZE_MD = 16;

--- a/src/hooks/queries/useBoardDetailQueries.ts
+++ b/src/hooks/queries/useBoardDetailQueries.ts
@@ -1,0 +1,48 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { deletePost, getBoardComments, getBoardDetail, likePost, postComment } from '@/api/board';
+import { BOARD_COMMENTS_STALE_TIME_MS, BOARD_DETAIL_STALE_TIME_MS } from '@/constants/common';
+
+export function useBoardDetailQuery(uuid?: string) {
+  return useQuery({
+    queryKey: ['board-detail', uuid] as const,
+    queryFn: () => getBoardDetail(uuid!),
+    enabled: !!uuid,
+    staleTime: BOARD_DETAIL_STALE_TIME_MS,
+  });
+}
+
+export function useBoardCommentsQuery(uuid?: string, enabled: boolean = true) {
+  return useQuery({
+    queryKey: ['board-comments', uuid] as const,
+    queryFn: () => getBoardComments(uuid!),
+    enabled: !!uuid && enabled,
+    staleTime: BOARD_COMMENTS_STALE_TIME_MS,
+  });
+}
+
+export function usePostCommentMutation(uuid?: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (content: string) => postComment(uuid!, content),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['board-comments', uuid] });
+      queryClient.invalidateQueries({ queryKey: ['board-detail', uuid] });
+    },
+  });
+}
+
+export function useLikePostMutation(uuid?: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => likePost(uuid!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['board-detail', uuid] });
+    },
+  });
+}
+
+export function useDeletePostMutation(uuid?: string) {
+  return useMutation({
+    mutationFn: () => deletePost(uuid!),
+  });
+}

--- a/src/hooks/queries/useBoardQuery.ts
+++ b/src/hooks/queries/useBoardQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { getBoards, type Category } from '@/api/board';
+import { BOARD_STALE_TIME_MS } from '@/constants/common';
+
+export function useBoardQuery(category: Category, page: number, size: number) {
+  return useQuery({
+    queryKey: ['boards', category, page, size],
+    queryFn: () => getBoards({ page, size, communityCategory: category }),
+    staleTime: BOARD_STALE_TIME_MS,
+    placeholderData: (prev) => prev,
+  });
+}

--- a/src/hooks/queries/useBroadcastPageQuery.ts
+++ b/src/hooks/queries/useBroadcastPageQuery.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchBroadcasts, searchBroadcasts } from '@/api/main/broadcast-api';
+import { BROADCAST_PAGE_SIZE, BROADCAST_SEARCH_STALE_TIME_MS } from '@/constants/common';
+
+export function useBroadcastListQuery(page: number, size: number = BROADCAST_PAGE_SIZE) {
+  return useQuery({
+    queryKey: ['broadcast-page', 'list', page, size] as const,
+    queryFn: () => fetchBroadcasts(page, size),
+    staleTime: BROADCAST_SEARCH_STALE_TIME_MS,
+    placeholderData: (prev) => prev,
+  });
+}
+
+export function useBroadcastSearchQuery(
+  keyword: string,
+  page: number,
+  size: number = BROADCAST_PAGE_SIZE,
+) {
+  return useQuery({
+    queryKey: ['broadcast-page', 'search', keyword, page, size] as const,
+    queryFn: () => searchBroadcasts(keyword, 'relevance', page, size),
+    enabled: !!keyword.trim(),
+    staleTime: BROADCAST_SEARCH_STALE_TIME_MS,
+    placeholderData: (prev) => prev,
+  });
+}

--- a/src/hooks/queries/useBroadcastQuery.ts
+++ b/src/hooks/queries/useBroadcastQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchBroadcasts } from '@/api/main/broadcast-api';
+import { BROADCAST_STALE_TIME_MS } from '@/constants/common';
+
+export function useBroadcastQuery(page: number, size: number) {
+  return useQuery({
+    queryKey: ['broadcasts', page, size],
+    queryFn: () => fetchBroadcasts(page, size),
+    staleTime: BROADCAST_STALE_TIME_MS,
+    placeholderData: (prev) => prev,
+  });
+}

--- a/src/hooks/queries/useDepartmentQueries.ts
+++ b/src/hooks/queries/useDepartmentQueries.ts
@@ -1,0 +1,67 @@
+import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
+import {
+  getDepartmentInfo,
+  getDepartmentNotices,
+  getDepartmentSchedules,
+  getStudentCouncilNotices,
+  type College,
+  type Department,
+} from '@/api/departments';
+import {
+  DEPARTMENT_INFO_STALE_TIME_MS,
+  DEPARTMENT_NOTICE_STALE_TIME_MS,
+  DEPARTMENT_SCHEDULE_STALE_TIME_MS,
+} from '@/constants/common';
+
+const NOTICE_PAGE_SIZE = 5;
+const POSTS_PAGE_SIZE = 12;
+
+export function useDepartmentInfoQuery(college: College, department: Department | null) {
+  return useQuery({
+    queryKey: ['department-info', college, department],
+    queryFn: () => getDepartmentInfo(college, department),
+    staleTime: DEPARTMENT_INFO_STALE_TIME_MS,
+    select: (res) => res.data ?? null,
+  });
+}
+
+export function useDepartmentSchedulesQuery(college: College, department: Department | null) {
+  return useQuery({
+    queryKey: ['department-schedules', college, department],
+    queryFn: () => getDepartmentSchedules(college, department),
+    staleTime: DEPARTMENT_SCHEDULE_STALE_TIME_MS,
+    select: (res) => res.data?.schedules ?? [],
+  });
+}
+
+export function useDepartmentNoticesQuery(
+  college: College,
+  department: Department | null,
+  page: number,
+) {
+  return useQuery({
+    queryKey: ['department-notices', college, department, page],
+    queryFn: () =>
+      getDepartmentNotices(college, department, page, NOTICE_PAGE_SIZE, 'date,desc'),
+    staleTime: DEPARTMENT_NOTICE_STALE_TIME_MS,
+    placeholderData: (prev) => prev,
+    select: (res) => res.data,
+  });
+}
+
+export function useStudentCouncilNoticesInfiniteQuery(
+  college: College,
+  department: Department | null,
+) {
+  return useInfiniteQuery({
+    queryKey: ['student-council-notices', college, department],
+    queryFn: ({ pageParam }) =>
+      getStudentCouncilNotices(college, department, pageParam, POSTS_PAGE_SIZE, 'publishedAt').then(
+        (r) => r.data,
+      ),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) =>
+      lastPage?.last ? undefined : (lastPage?.number ?? 0) + 1,
+    staleTime: DEPARTMENT_NOTICE_STALE_TIME_MS,
+  });
+}

--- a/src/hooks/queries/useMyPageQueries.ts
+++ b/src/hooks/queries/useMyPageQueries.ts
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  getMyComments,
+  getMyLikedPosts,
+  getMyPosts,
+  getProfileStats,
+  type MyCommentedPostItem,
+  type MyPostItem,
+  type ProfileStatsRes,
+} from '@/api/mypage';
+import { MYPAGE_STALE_TIME_MS } from '@/constants/common';
+import type { Paginated } from '@/api/types';
+
+export function useProfileStatsQuery() {
+  return useQuery<ProfileStatsRes>({
+    queryKey: ['mypage', 'stats'] as const,
+    queryFn: getProfileStats,
+    staleTime: MYPAGE_STALE_TIME_MS,
+  });
+}
+
+export function useMyPostsQuery(page: number, size: number = 10) {
+  return useQuery<Paginated<MyPostItem>>({
+    queryKey: ['mypage', 'posts', page, size] as const,
+    queryFn: () => getMyPosts(page, size),
+    staleTime: MYPAGE_STALE_TIME_MS,
+    placeholderData: (prev) => prev,
+  });
+}
+
+export function useMyCommentsQuery(page: number, size: number = 10) {
+  return useQuery<Paginated<MyCommentedPostItem>>({
+    queryKey: ['mypage', 'comments', page, size] as const,
+    queryFn: () => getMyComments(page, size),
+    staleTime: MYPAGE_STALE_TIME_MS,
+    placeholderData: (prev) => prev,
+  });
+}
+
+export function useMyLikedPostsQuery(page: number, size: number = 10) {
+  return useQuery<Paginated<MyPostItem>>({
+    queryKey: ['mypage', 'likes', page, size] as const,
+    queryFn: () => getMyLikedPosts(page, size),
+    staleTime: MYPAGE_STALE_TIME_MS,
+    placeholderData: (prev) => prev,
+  });
+}

--- a/src/hooks/queries/useNewsQuery.ts
+++ b/src/hooks/queries/useNewsQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchNewsInfo } from '@/api/news';
+import { NEWS_STALE_TIME_MS } from '@/constants/common';
+
+export function useNewsQuery(category: string, page: number, size: number) {
+  return useQuery({
+    queryKey: ['news', category, page, size],
+    queryFn: () => fetchNewsInfo(category, page, size),
+    staleTime: NEWS_STALE_TIME_MS,
+    placeholderData: (prev) => prev,
+  });
+}

--- a/src/hooks/queries/useNoticeQuery.ts
+++ b/src/hooks/queries/useNoticeQuery.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchNotionInfo } from '@/api/main/notice-api';
+import { NOTICE_API_DEFAULT_SIZE, NOTICE_STALE_TIME_MS } from '@/constants/common';
+
+export function useNoticeQuery(
+  category: string,
+  page: number,
+  size: number = NOTICE_API_DEFAULT_SIZE,
+  sort: 'asc' | 'desc' = 'desc',
+) {
+  return useQuery({
+    queryKey: ['notices', category, page, size, sort],
+    queryFn: () => fetchNotionInfo(category, page, size, sort),
+    staleTime: NOTICE_STALE_TIME_MS,
+    placeholderData: (prev) => prev,
+  });
+}

--- a/src/hooks/queries/useRealtimeKeywordQuery.ts
+++ b/src/hooks/queries/useRealtimeKeywordQuery.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getRealTimeSearch } from '@/api/main/real-time';
+import { HOT_KEYWORDS_STALE_TIME_MS } from '@/constants/common';
+
+export function useRealtimeKeywordQuery(count: number = 6) {
+  return useQuery({
+    queryKey: ['search', 'realtime-keywords', count] as const,
+    queryFn: () => getRealTimeSearch(count),
+    staleTime: HOT_KEYWORDS_STALE_TIME_MS,
+  });
+}

--- a/src/hooks/queries/useSearchQueries.ts
+++ b/src/hooks/queries/useSearchQueries.ts
@@ -1,0 +1,61 @@
+import { useQuery, useQueries } from '@tanstack/react-query';
+import { getSearchResult, getSearchAISummary, getSearchWordcompletion } from '@/api/search';
+import {
+  AI_SUMMARY_STALE_TIME_MS,
+  SEARCH_STALE_TIME_MS,
+  SEARCH_SUGGEST_STALE_TIME_MS,
+} from '@/constants/common';
+import type { Sort } from '@/components/molecules/SortButtons';
+
+type AllSearchType = 'NOTICE' | 'COMMUNITY' | 'NEWS' | 'BROADCAST';
+
+/** ALL 탭 전용: 4가지 타입을 병렬로 조회 */
+export function useAllSearchQueries(keyword: string | null, sort: Sort) {
+  return useQueries({
+    queries: (['NOTICE', 'COMMUNITY', 'NEWS', 'BROADCAST'] as AllSearchType[]).map((type) => ({
+      queryKey: ['search', 'all', type, keyword, sort] as const,
+      queryFn: () => getSearchResult(keyword!, type, 'all', sort),
+      enabled: !!keyword,
+      staleTime: SEARCH_STALE_TIME_MS,
+    })),
+  });
+}
+
+/** 개별 탭 전용: 단일 타입 조회 */
+export function useSearchQuery(
+  keyword: string | null,
+  type: Parameters<typeof getSearchResult>[1],
+  category: string,
+  sort: Sort,
+  page: number,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: ['search', 'detail', type, keyword, category, sort, page] as const,
+    queryFn: () => getSearchResult(keyword!, type, category, sort, page, 10),
+    enabled: enabled && !!keyword,
+    staleTime: SEARCH_STALE_TIME_MS,
+    placeholderData: (prev) => prev,
+  });
+}
+
+/** AI 요약: keyword 변경 시에만 재조회, 10분 stale */
+export function useAiSummaryQuery(keyword: string | null) {
+  return useQuery({
+    queryKey: ['search', 'ai-summary', keyword] as const,
+    queryFn: () => getSearchAISummary(keyword!),
+    enabled: !!keyword,
+    staleTime: AI_SUMMARY_STALE_TIME_MS,
+    retry: 0,
+  });
+}
+
+/** 자동완성: signal 전달로 실제 HTTP 요청 취소, 1분 stale */
+export function useSearchSuggestQuery(keyword: string) {
+  return useQuery({
+    queryKey: ['search', 'suggest', keyword] as const,
+    queryFn: ({ signal }) => getSearchWordcompletion(keyword, signal),
+    enabled: !!keyword.trim(),
+    staleTime: SEARCH_SUGGEST_STALE_TIME_MS,
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,7 +8,15 @@ import { Toaster } from 'react-hot-toast';
 import { initAuth } from '@/api/initAuth';
 import React from 'react';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 1,
+      gcTime: 10 * 60 * 1000,
+    },
+  },
+});
 const root = createRoot(document.getElementById('root')!);
 
 (async () => {

--- a/src/pages/board/detail/index.tsx
+++ b/src/pages/board/detail/index.tsx
@@ -1,12 +1,4 @@
-import {
-  deletePost,
-  getBoardComments,
-  getBoardDetail,
-  likePost,
-  postComment,
-  type CommentRes,
-  type GetBoardDetailRes,
-} from '@/api/board';
+import { type CommentRes } from '@/api/board';
 import NavigationUp from '@/components/molecules/NavigationUp';
 import BlockTextEditor from '@/components/organisms/BlockTextEditor';
 import GlobalErrorPage from '@/pages/error';
@@ -20,19 +12,16 @@ import { useAuthStore } from '@/store/useAuthStore';
 import { handleError } from '@/utils/error';
 import { ChatBubbleIcon, HeartIcon } from '@/components/atoms/Icon';
 import { formatToDotDate } from '@/utils/date';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  useBoardCommentsQuery,
+  useBoardDetailQuery,
+  useDeletePostMutation,
+  useLikePostMutation,
+  usePostCommentMutation,
+} from '@/hooks/queries/useBoardDetailQueries';
 
 const MAX_REPLY_LEN = 100;
-
-interface BoardDetail {
-  id: string;
-  title: string;
-  date: string;
-  author: string;
-  viewCount: number;
-  commentCount: number;
-  likeCount: number;
-  content: string;
-}
 
 /**
  * 게시판 상세 페이지
@@ -44,55 +33,27 @@ interface BoardDetail {
 export default function BoardDetail() {
   const navigate = useNavigate();
   const { uuid } = useParams<{ uuid: string }>();
-  const [content, setContent] = useState<GetBoardDetailRes | null>(null);
-  const [comments, setComments] = useState<CommentRes[] | null>(null);
-  const [isContentLoading, setIsContentLoading] = useState(true);
-  const [isCommentsLoading, setIsCommentsLoading] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [isCommentUploading, setIsCommentUploading] = useState(false);
   const [newComment, setNewComment] = useState('');
   const [isError, setIsError] = useState(false);
   const { isLoggedIn } = useAuthStore();
+  const queryClient = useQueryClient();
+  const contentQuery = useBoardDetailQuery(uuid);
+  const commentsQuery = useBoardCommentsQuery(uuid, isLoggedIn);
+  const postCommentMutation = usePostCommentMutation(uuid);
+  const likePostMutation = useLikePostMutation(uuid);
+  const deletePostMutation = useDeletePostMutation(uuid);
+  const content = contentQuery.data ?? null;
+  const comments: CommentRes[] | null = isLoggedIn ? (commentsQuery.data ?? []) : null;
+  const isContentLoading = contentQuery.isLoading;
+  const isCommentsLoading = isLoggedIn ? commentsQuery.isLoading : false;
 
-  // 페이지 로드 함수 (로그인된 경우에만 댓글 API 조회)
   useEffect(() => {
-    if (!uuid) return;
-    getContent(uuid);
-    if (isLoggedIn) {
-      getComments(uuid);
-    } else {
-      setComments(null);
-      setIsCommentsLoading(false);
-    }
-  }, [uuid, isLoggedIn]);
-
-  // 게시글 데이터 로드
-  const getContent = async (uuid: string) => {
-    setIsContentLoading(true);
-    try {
-      const res = await getBoardDetail(uuid);
-      setContent(res);
-    } catch (e) {
-      handleError(e, '게시글을 불러오는 중 오류가 발생했습니다.', { showToast: false });
+    if (contentQuery.isError || commentsQuery.isError) {
       setIsError(true);
-    } finally {
-      setIsContentLoading(false);
     }
-  };
-
-  // 댓글 데이터 로드
-  const getComments = async (uuid: string) => {
-    setIsCommentsLoading(true);
-    try {
-      const res = await getBoardComments(uuid);
-      setComments(res);
-    } catch (e) {
-      handleError(e, '댓글을 불러오는 중 오류가 발생했습니다.', { showToast: false });
-      setIsError(true);
-    } finally {
-      setIsCommentsLoading(false);
-    }
-  };
+  }, [contentQuery.isError, commentsQuery.isError]);
 
   // 댓글 작성 요청
   const handleCommentUpload = async () => {
@@ -108,8 +69,7 @@ export default function BoardDetail() {
 
     try {
       setIsCommentUploading(true);
-      await postComment(uuid, newComment);
-      await getComments(uuid);
+      await postCommentMutation.mutateAsync(newComment);
       setNewComment('');
     } catch (err) {
       handleError(err, '댓글 작성에 실패했습니다.');
@@ -128,16 +88,9 @@ export default function BoardDetail() {
     }
     setIsLoading(true);
     try {
-      await likePost(uuid);
       const wasLiked = content.isLiked;
-      setContent((prev) => {
-        if (!prev) return null;
-        return {
-          ...prev,
-          likeCount: prev.isLiked ? prev.likeCount - 1 : prev.likeCount + 1,
-          isLiked: !prev.isLiked,
-        };
-      });
+      await likePostMutation.mutateAsync();
+      await queryClient.invalidateQueries({ queryKey: ['board-detail', uuid] });
       if (!wasLiked) {
         toast.success('좋아요를 표시했습니다.');
       }
@@ -154,7 +107,7 @@ export default function BoardDetail() {
     if (!window.confirm('게시글을 삭제하시겠습니까?')) return;
     try {
       setIsLoading(true);
-      await deletePost(uuid);
+      await deletePostMutation.mutateAsync();
       toast.success('게시글이 삭제되었습니다.');
       navigate(-1);
     } catch (err) {

--- a/src/pages/broadcast/index.tsx
+++ b/src/pages/broadcast/index.tsx
@@ -1,13 +1,17 @@
 import { Link, useSearchParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { formatToLocalDate } from '@/utils';
-import { fetchBroadcasts, searchBroadcasts, type BroadcastItem } from '@/api/main/broadcast-api';
+import { type BroadcastItem } from '@/api/main/broadcast-api';
 import LoadingIndicator from '@/components/atoms/LoadingIndicator';
 import Pagination from '@/components/molecules/common/Pagination';
 import { useResponsive } from '@/hooks/useResponse';
 import SearchBar from '@/components/atoms/SearchBar';
 import { HighlightedText } from '@/components/atoms/HighlightedText';
 import { BROADCAST_PAGE_SIZE } from '@/constants/common';
+import {
+  useBroadcastListQuery,
+  useBroadcastSearchQuery,
+} from '@/hooks/queries/useBroadcastPageQuery';
 
 /**
  * 명대방송 페이지
@@ -22,10 +26,9 @@ export default function Broadcast() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [initialKeyword, setInitialKeyword] = useState('');
   const keyword = searchParams.get('keyword');
-  const [totalPage, setTotalPage] = useState(1);
   const page = Number(searchParams.get('page') || '0');
-  const [contents, setContents] = useState<BroadcastItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const normalizedKeyword = (keyword ?? '').trim();
+  const hasKeyword = normalizedKeyword.length > 0;
 
   /**
    * 페이지 번호를 url에 반영합니다
@@ -44,43 +47,16 @@ export default function Broadcast() {
     else setInitialKeyword('');
   }, [keyword]);
 
-  useEffect(() => {
-    /**
-     * 검색어 없는 경우 모든 데이터 조회
-     */
-    if (!keyword) {
-      (async () => {
-        try {
-          setIsLoading(true);
-          const res = await fetchBroadcasts(page, BROADCAST_PAGE_SIZE);
-          setTotalPage(res.totalPages);
-          setContents(res.content);
-        } catch (err) {
-          console.error(err);
-        } finally {
-          setIsLoading(false);
-        }
-      })();
-    }
+  const listQuery = useBroadcastListQuery(page, BROADCAST_PAGE_SIZE);
+  const searchQuery = useBroadcastSearchQuery(normalizedKeyword, page, BROADCAST_PAGE_SIZE);
 
-    /**
-     * 검색어 있는 경우 검색 요청
-     */
-    if (keyword) {
-      (async () => {
-        try {
-          setIsLoading(true);
-          const res = await searchBroadcasts(keyword, 'relevance', page, BROADCAST_PAGE_SIZE);
-          setContents(res.data);
-          setTotalPage(res.totalPages);
-        } catch (e) {
-          console.error(e);
-        } finally {
-          setIsLoading(false);
-        }
-      })();
-    }
-  }, [page, keyword]);
+  const isLoading = hasKeyword ? searchQuery.isLoading : listQuery.isLoading;
+  const contents: BroadcastItem[] = hasKeyword
+    ? (searchQuery.data?.data ?? [])
+    : (listQuery.data?.content ?? []);
+  const totalPage = hasKeyword
+    ? (searchQuery.data?.totalPages ?? 1)
+    : (listQuery.data?.totalPages ?? 1);
 
   /**
    * 로딩 페이지

--- a/src/pages/departments/index.tsx
+++ b/src/pages/departments/index.tsx
@@ -20,20 +20,14 @@ import {
   DEPARTMENT_OPTIONS,
   departmentMap,
 } from '@/constants/departments';
+import type { College, Department, DepartmentSchedule } from '@/api/departments';
 import {
-  getDepartmentInfo,
-  getDepartmentNotices,
-  getDepartmentSchedules,
-  getStudentCouncilNotices,
-  type College,
-  type Department,
-  type DepartmentInfo,
-  type DepartmentNotice,
-  type DepartmentSchedule,
-  type StudentCouncilNotice,
-} from '@/api/departments';
+  useDepartmentInfoQuery,
+  useDepartmentNoticesQuery,
+  useDepartmentSchedulesQuery,
+  useStudentCouncilNoticesInfiniteQuery,
+} from '@/hooks/queries/useDepartmentQueries';
 
-// 페이지 탭 구성
 const TABS = {
   events: '소속 일정',
   notices: '소속 공지사항',
@@ -64,7 +58,6 @@ function readStoredDepartmentSelection(): StoredSelection | null {
   }
 }
 
-// 관리자 권한 체크
 const hasAdminPermission = (role: string | undefined): boolean => {
   return role === 'OPERATOR' || role === 'ADMIN';
 };
@@ -75,21 +68,18 @@ export default function DepartmentMainPage() {
   const navigate = useNavigate();
   const isDepartmentSlideActive = activeMainSlide === 0;
 
-  // 단과대 필터 (비로그인 시 기본: 경영대학, 학과 null) — 세션 스토리지에서 복원
   const [selectedCollege, setSelectedCollege] = useState<College>(() => {
     const stored = readStoredDepartmentSelection();
     return stored?.college ?? 'BUSINESS';
   });
   const [isCollegeDrawerOpen, setIsCollegeDrawerOpen] = useState(false);
 
-  // 학과 필터 — 세션 스토리지에서 복원
   const [selectedDepartment, setSelectedDepartment] = useState<Department | null>(() => {
     const stored = readStoredDepartmentSelection();
     return stored?.department ?? null;
   });
   const [isDepartmentDrawerOpen, setIsDepartmentDrawerOpen] = useState(false);
 
-  // 선택한 단과대/학과를 세션 스토리지에 저장
   useEffect(() => {
     sessionStorage.setItem(
       DEPARTMENT_STORAGE_KEY,
@@ -97,48 +87,10 @@ export default function DepartmentMainPage() {
     );
   }, [selectedCollege, selectedDepartment]);
 
-  // 학과 정보 (API 응답)
-  const [departmentInfo, setDepartmentInfo] = useState<DepartmentInfo | null>(null);
-
-  // 학과 일정 (API 응답)
-  const [departmentSchedules, setDepartmentSchedules] = useState<DepartmentSchedule[]>([]);
-
-  // 소속 공지사항 (학과 공지사항 API)
-  const [departmentNotices, setDepartmentNotices] = useState<DepartmentNotice[]>([]);
-  const [noticePage, setNoticePage] = useState(0);
-  const [noticeTotalPages, setNoticeTotalPages] = useState(0);
-  const NOTICE_PAGE_SIZE = 5;
-
-  // 학생회 공지사항 (페이지네이션 + 무한 스크롤)
-  const [studentCouncilNotices, setStudentCouncilNotices] = useState<StudentCouncilNotice[]>([]);
-  const [postsPage, setPostsPage] = useState(0);
-  const [postsLast, setPostsLast] = useState(false);
-  const [isPostsLoading, setIsPostsLoading] = useState(false);
-  const POSTS_PAGE_SIZE = 12;
-  const postsLoadMoreRef = useRef<HTMLDivElement>(null);
-
-  // 응답 시점에 선택된 필터와 일치할 때만 반영
-  const filterRef = useRef({
-    college: selectedCollege,
-    department: selectedDepartment,
-    noticePage,
-    postsPage: 0,
-  });
-  useEffect(() => {
-    filterRef.current = {
-      college: selectedCollege,
-      department: selectedDepartment,
-      noticePage,
-      postsPage,
-    };
-  }, [selectedCollege, selectedDepartment, noticePage, postsPage]);
-
-  // 선택이 기본값(경영대 전체)일 때만 사용자 소속 college/학과로 자동 설정 (저장된 선택은 유지)
+  // 로그인 사용자 소속으로 자동 설정 (기본값일 때만)
   useEffect(() => {
     if (selectedCollege !== 'BUSINESS' || selectedDepartment !== null) return;
-
     if (user?.departmentName) {
-      // 학과 소속이 있는 경우: college + department 모두 자동 설정
       for (const option of DEPARTMENT_OPTIONS) {
         const department = option.departments.find((dept) => dept.value === user.departmentName);
         if (department) {
@@ -148,80 +100,69 @@ export default function DepartmentMainPage() {
         }
       }
     } else if (user?.college) {
-      // 단과대만 소속된 경우(department null): college만 자동 설정, department는 null 유지
       const validCollege = COLLEGE_OPTIONS.find((opt) => opt.value === user.college);
-      if (validCollege) {
-        setSelectedCollege(validCollege.value as College);
-      }
+      if (validCollege) setSelectedCollege(validCollege.value as College);
     }
   }, [user?.college, user?.departmentName, selectedCollege, selectedDepartment]);
 
-  // 선택된 college, department로 학과 정보 조회 (전체 선택 시 department는 null로 요청)
+  // --- React Query 데이터 조회 ---
+  const { data: departmentInfo } = useDepartmentInfoQuery(selectedCollege, selectedDepartment);
+  const { data: departmentSchedules = [] } = useDepartmentSchedulesQuery(
+    selectedCollege,
+    selectedDepartment,
+  );
+
+  const [noticePage, setNoticePage] = useState(0);
+  const { data: noticesData } = useDepartmentNoticesQuery(
+    selectedCollege,
+    selectedDepartment,
+    noticePage,
+  );
+  const departmentNotices = noticesData?.content ?? [];
+  const noticeTotalPages = noticesData?.totalPages ?? 0;
+
+  const {
+    data: postsData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useStudentCouncilNoticesInfiniteQuery(selectedCollege, selectedDepartment);
+  const studentCouncilNotices = postsData?.pages.flatMap((p) => p?.content ?? []) ?? [];
+
+  const postsLoadMoreRef = useRef<HTMLDivElement>(null);
+
+  // 무한 스크롤 IntersectionObserver
   useEffect(() => {
-    const college = selectedCollege;
-    const department = selectedDepartment;
-    (async () => {
-      try {
-        const response = await getDepartmentInfo(college, department);
-        const info = response.data;
-        if (filterRef.current.college !== college || filterRef.current.department !== department)
-          return;
-        if (info) {
-          setDepartmentInfo(info);
-        } else {
-          setDepartmentInfo(null);
+    const el = postsLoadMoreRef.current;
+    if (!el || !hasNextPage || isFetchingNextPage) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
         }
-      } catch (e) {
-        if (filterRef.current.college !== college || filterRef.current.department !== department)
-          return;
-        console.error(e);
-        setDepartmentInfo(null);
-      }
-    })();
-  }, [selectedCollege, selectedDepartment]);
+      },
+      { root: null, rootMargin: '100px', threshold: 0 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  // 선택된 college, department로 학과 일정 조회
-  useEffect(() => {
-    const college = selectedCollege;
-    const department = selectedDepartment;
-    (async () => {
-      try {
-        const response = await getDepartmentSchedules(college, department);
-        const list = response.data?.schedules ?? [];
-        if (filterRef.current.college !== college || filterRef.current.department !== department)
-          return;
-        setDepartmentSchedules(list);
-      } catch (e) {
-        if (filterRef.current.college !== college || filterRef.current.department !== department)
-          return;
-        console.error(e);
-        setDepartmentSchedules([]);
-      }
-    })();
-  }, [selectedCollege, selectedDepartment]);
-
-  // 선택된 단과대에 해당하는 학과 목록 가져오기
   const availableDepartments =
     DEPARTMENT_OPTIONS.find((option) => option.college.value === selectedCollege)?.departments ||
     [];
 
-  // 현재 사용자의 college, department (auth 기준)
-  // user.college 필드를 우선 사용하고, 없을 경우 departmentName으로 유추
   const userCollege: College | undefined =
     (user?.college as College | undefined) ??
     DEPARTMENT_OPTIONS.find((opt) => opt.departments.some((d) => d.value === user?.departmentName))
       ?.college?.value;
   const userDepartment = user?.departmentName ?? null;
 
-  // 필터가 사용자의 college, department와 일치할 때만 편집 UI 표시
-  // department가 null인 단과대 관리자의 경우 소속 college + department 미선택(null) 뷰에서 편집 허용
   const canEditDepartment =
     hasAdminPermission(user?.role) &&
     userCollege !== undefined &&
     selectedCollege === userCollege &&
     selectedDepartment === userDepartment;
 
-  // 탭 선택 (세션 스토리지에 저장·복원)
   const TAB_STORAGE_KEY = 'department-tab';
   const [currentTab, setCurrentTab] = useState<string>(() => {
     const saved = sessionStorage.getItem(TAB_STORAGE_KEY);
@@ -231,12 +172,10 @@ export default function DepartmentMainPage() {
     sessionStorage.setItem(TAB_STORAGE_KEY, currentTab);
   }, [currentTab]);
 
-  // 소속 일정 (캘린더 현재 연·월 추적)
   const [currentYear, setCurrentYear] = useState<number>(new Date().getFullYear());
   const [currentMonth, setCurrentMonth] = useState<number>(new Date().getMonth() + 1);
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
 
-  // 캘린더 연·월 이동 시 선택된 날짜 초기화
   const handleYearChange = (year: number) => {
     setCurrentYear(year);
     setSelectedDate(null);
@@ -246,7 +185,6 @@ export default function DepartmentMainPage() {
     setSelectedDate(null);
   };
 
-  // 선택한 날짜에 해당하는 학과 일정 (선택 없으면 현재 달의 전체 일정)
   const dayEvents = useMemo(() => {
     let list: DepartmentSchedule[];
     if (selectedDate) {
@@ -274,7 +212,6 @@ export default function DepartmentMainPage() {
     );
   }, [departmentSchedules, selectedDate, currentYear, currentMonth]);
 
-  // 교학팀 전화번호 복사 완료 상태
   const [phoneCopied, setPhoneCopied] = useState(false);
   const handleCopyPhone = async () => {
     const phone = departmentInfo?.academicOfficePhone;
@@ -288,121 +225,9 @@ export default function DepartmentMainPage() {
     }
   };
 
-  // 선택된 college, department로 학과 공지사항(소속 공지사항) 조회
-  useEffect(() => {
-    const college = selectedCollege;
-    const department = selectedDepartment;
-    const page = noticePage;
-    (async () => {
-      try {
-        const response = await getDepartmentNotices(
-          college,
-          department,
-          page,
-          NOTICE_PAGE_SIZE,
-          'date,desc',
-        );
-        const payload = response.data;
-        if (
-          filterRef.current.college !== college ||
-          filterRef.current.department !== department ||
-          filterRef.current.noticePage !== page
-        )
-          return;
-        setDepartmentNotices(payload?.content ?? []);
-        setNoticeTotalPages(payload?.totalPages ?? 0);
-      } catch (e) {
-        if (
-          filterRef.current.college !== college ||
-          filterRef.current.department !== department ||
-          filterRef.current.noticePage !== page
-        )
-          return;
-        console.error(e);
-        setDepartmentNotices([]);
-        setNoticeTotalPages(0);
-      }
-    })();
-  }, [selectedCollege, selectedDepartment, noticePage]);
-
-  // 단과대/학과 변경 시 학생회 공지 페이지 초기화
-  useEffect(() => {
-    setPostsPage(0);
-    setPostsLast(false);
-  }, [selectedCollege, selectedDepartment]);
-
-  // 선택된 college, department로 학생회 공지사항 조회 (페이지네이션, 하단 도달 시 다음 페이지)
-  useEffect(() => {
-    const college = selectedCollege;
-    const department = selectedDepartment;
-    const page = postsPage;
-    if (page === 0) setStudentCouncilNotices([]);
-    setIsPostsLoading(true);
-    (async () => {
-      try {
-        const response = await getStudentCouncilNotices(
-          college,
-          department,
-          page,
-          POSTS_PAGE_SIZE,
-          'publishedAt',
-        );
-        const payload = response.data;
-        const notices = payload?.content ?? [];
-        if (
-          filterRef.current.college !== college ||
-          filterRef.current.department !== department ||
-          filterRef.current.postsPage !== page
-        )
-          return;
-        if (page === 0) {
-          setStudentCouncilNotices(notices);
-        } else {
-          setStudentCouncilNotices((prev) => [...prev, ...notices]);
-        }
-        setPostsLast(payload?.last ?? true);
-      } catch (e) {
-        if (
-          filterRef.current.college !== college ||
-          filterRef.current.department !== department ||
-          filterRef.current.postsPage !== page
-        )
-          return;
-        console.error(e);
-        if (page === 0) setStudentCouncilNotices([]);
-      } finally {
-        if (
-          filterRef.current.college === college &&
-          filterRef.current.department === department &&
-          filterRef.current.postsPage === page
-        ) {
-          setIsPostsLoading(false);
-        }
-      }
-    })();
-  }, [selectedCollege, selectedDepartment, postsPage]);
-
-  // 학생회 공지사항: 하단 sentinel이 보이면 다음 페이지 로드
-  useEffect(() => {
-    const el = postsLoadMoreRef.current;
-    if (!el || postsLast || isPostsLoading) return;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const [entry] = entries;
-        if (entry?.isIntersecting && !postsLast && !isPostsLoading) {
-          setPostsPage((prev) => prev + 1);
-        }
-      },
-      { root: null, rootMargin: '100px', threshold: 0 },
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [postsLast, isPostsLoading, currentTab]);
-
   return (
     <section className='flex min-h-screen flex-col'>
       <div className='flex gap-2 px-5 py-4'>
-        {/* 단과대 필터 */}
         <button
           className={clsx(
             'flex cursor-pointer items-center gap-1 rounded-full px-3 py-1.5',
@@ -418,7 +243,6 @@ export default function DepartmentMainPage() {
           <IoIosArrowDown className='text-grey-40 flex-shrink-0' />
         </button>
 
-        {/* 학과 필터 */}
         <button
           className={clsx(
             'flex cursor-pointer items-center gap-1 rounded-full px-3 py-1.5',
@@ -442,17 +266,12 @@ export default function DepartmentMainPage() {
 
       <div className='flex flex-1 flex-col'>
         <div className='flex flex-col px-5 pt-5 pb-6.5'>
-          {/* 단과대 이름 */}
           <p className='text-title03 text-black'>{collegeMap.get(selectedCollege)}</p>
-
-          {/* 학과 이름 */}
           {selectedDepartment && (
             <p className='text-body04 text-grey-80 mt-0.5'>
               {departmentMap.get(selectedDepartment)}
             </p>
           )}
-
-          {/* 교학팀 전화번호 */}
           <div className='mt-2.5 flex items-center gap-1'>
             <span className='text-body05 text-grey-80'>교학팀</span>
             <span className='text-body05 text-grey-30'>
@@ -471,8 +290,6 @@ export default function DepartmentMainPage() {
               )}
             </button>
           </div>
-
-          {/* 홈페이지 / 인스타 버튼 */}
           <div className='flex gap-3 pt-3.5'>
             {departmentInfo?.homepageUrl ? (
               <a
@@ -499,7 +316,6 @@ export default function DepartmentMainPage() {
           </div>
         </div>
 
-        {/* 탭 선택 */}
         <div className='border-grey-10 border-b-1 px-5'>
           <Tabs
             tabs={TABS}
@@ -509,7 +325,6 @@ export default function DepartmentMainPage() {
           />
         </div>
 
-        {/* 소속 일정 탭 */}
         {currentTab === 'events' && (
           <section className='relative'>
             <div className='flex flex-col'>
@@ -520,8 +335,6 @@ export default function DepartmentMainPage() {
                 onMonthChange={handleMonthChange}
                 onDateSelect={setSelectedDate}
               />
-
-              {/* 캘린더 범례 */}
               <div className='mt-3 flex items-center justify-end px-5'>
                 <p className='bg-blue-35 h-2.5 w-2.5' />
                 <p className='text-caption04 text-grey-40 ms-1'>전체 (학부·대학원)</p>
@@ -532,8 +345,6 @@ export default function DepartmentMainPage() {
                 <p className='bg-grey-02 ms-4 h-2.5 w-2.5' />
                 <p className='text-caption04 text-grey-40 ms-1'>휴일</p>
               </div>
-
-              {/* 선택한 날짜 이벤트 목록 */}
               <div className='border-grey-02 mb-2 border-b-1 px-5 py-1'>
                 <span className='text-body02 text-mju-primary'>
                   {selectedDate
@@ -560,9 +371,7 @@ export default function DepartmentMainPage() {
                           canEditDepartment && 'cursor-pointer',
                         )}
                         onClick={() => {
-                          if (canEditDepartment) {
-                            navigate(`/departments/events/edit/${event.uuid}`);
-                          }
+                          if (canEditDepartment) navigate(`/departments/events/edit/${event.uuid}`);
                         }}
                       >
                         <span className='text-caption02 text-grey-40 w-20'>
@@ -580,15 +389,11 @@ export default function DepartmentMainPage() {
                 )}
               </div>
             </div>
-
-            {/* 일정 추가 버튼: 학과 슬라이드가 활성일 때만 표시 (다른 슬라이드에서 fixed 버튼이 겹치는 것 방지) */}
             {canEditDepartment && isDepartmentSlideActive && (
               <button
                 type='button'
                 className='bg-blue-35 fixed right-5 bottom-10 flex items-center justify-center rounded-full p-2 shadow-[0_0_12px_rgba(0,0,0,0.4)]'
-                onClick={() => {
-                  navigate('/departments/events/new');
-                }}
+                onClick={() => navigate('/departments/events/new')}
               >
                 <IoIosAdd className='text-4xl text-white' />
               </button>
@@ -596,7 +401,6 @@ export default function DepartmentMainPage() {
           </section>
         )}
 
-        {/* 소속 공지사항 탭 */}
         {currentTab === 'notices' && (
           <section className='flex flex-1 flex-col'>
             <div className='flex flex-1 flex-col py-5'>
@@ -630,7 +434,6 @@ export default function DepartmentMainPage() {
                   </div>
                 ))
               )}
-
               {departmentNotices.length > 0 && (
                 <Pagination
                   page={noticePage}
@@ -642,7 +445,6 @@ export default function DepartmentMainPage() {
           </section>
         )}
 
-        {/* 학생회 공지사항 탭 */}
         {currentTab === 'posts' && (
           <section>
             <div className='grid grid-cols-3 gap-1 py-5'>
@@ -668,19 +470,18 @@ export default function DepartmentMainPage() {
                 </Link>
               ))}
             </div>
-            {/* 무한 스크롤: 하단 도달 시 다음 페이지 로드 */}
-            {!postsLast && studentCouncilNotices.length > 0 && (
+            {hasNextPage && studentCouncilNotices.length > 0 && (
               <div
                 ref={postsLoadMoreRef}
                 className='flex min-h-12 items-center justify-center py-2'
                 aria-hidden
               >
-                {isPostsLoading && (
+                {isFetchingNextPage && (
                   <span className='text-caption02 text-grey-40'>불러오는 중...</span>
                 )}
               </div>
             )}
-            {studentCouncilNotices.length === 0 && !isPostsLoading && (
+            {studentCouncilNotices.length === 0 && !isFetchingNextPage && (
               <div
                 className={clsx(
                   'flex items-center justify-center',
@@ -694,13 +495,11 @@ export default function DepartmentMainPage() {
         )}
       </div>
 
-      {/* 단과대 필터 Drawer */}
       <Drawer open={isCollegeDrawerOpen} onOpenChange={setIsCollegeDrawerOpen}>
         <div className='flex flex-col gap-4 py-1.5'>
           <div className='px-5'>
             <h2 className='text-title02 text-black'>단과대 필터</h2>
           </div>
-
           <div className='flex flex-col'>
             {COLLEGE_OPTIONS.map((college) => {
               const isSelected = selectedCollege === college.value;
@@ -710,7 +509,7 @@ export default function DepartmentMainPage() {
                   type='button'
                   onClick={() => {
                     setSelectedCollege(college.value);
-                    setSelectedDepartment(null); // 단과대 변경 시 학과 필터 초기화
+                    setSelectedDepartment(null);
                     setNoticePage(0);
                     setIsCollegeDrawerOpen(false);
                   }}
@@ -730,15 +529,12 @@ export default function DepartmentMainPage() {
         </div>
       </Drawer>
 
-      {/* 학과 필터 Drawer */}
       <Drawer open={isDepartmentDrawerOpen} onOpenChange={setIsDepartmentDrawerOpen}>
         <div className='flex flex-col gap-4 py-1.5'>
           <div className='px-5'>
             <h2 className='text-title02 text-black'>학과 필터</h2>
           </div>
-
           <div className='flex flex-col'>
-            {/* 전체 옵션 */}
             <button
               type='button'
               onClick={() => {
@@ -756,8 +552,6 @@ export default function DepartmentMainPage() {
               전체
               {!selectedDepartment && <IoIosCheckmark className='text-2xl' />}
             </button>
-
-            {/* 학과 목록 */}
             {availableDepartments.map((department) => {
               const isSelected = selectedDepartment === department.value;
               return (
@@ -785,7 +579,6 @@ export default function DepartmentMainPage() {
         </div>
       </Drawer>
 
-      {/* Footer */}
       <div className='mt-auto'>
         <Footer />
       </div>

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -1,30 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import ActivitiesSection from '../../components/organisms/Mypage/ActivitiesSection';
-import { getProfileStats, type ProfileStatsRes } from '../../api/mypage';
 import ProfileCard from '../../components/molecules/user/ProfileCard';
 import LabelButton from '../../components/atoms/Button/LabelButton';
-import { handleError } from '../../utils/error';
 import { useAuthStore } from '../../store/useAuthStore';
 import LoginErrorPage from '../LoginError';
+import { useProfileStatsQuery } from '@/hooks/queries/useMyPageQueries';
 
 const Mypage: React.FC = () => {
   const user = useAuthStore((state) => state.user);
-  const [stateData, setStateData] = useState<ProfileStatsRes | null>(null);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const data = await getProfileStats();
-        setStateData(data);
-      } catch (err) {
-        handleError(err, '마이페이지 데이터를 불러오는 중 오류가 발생했습니다.', {
-          showToast: false,
-        });
-      }
-    };
-    fetchData();
-  }, []);
+  const { data: stateData } = useProfileStatsQuery();
 
   return (
     <div className='bg-grey-02 flex w-full flex-1 flex-col gap-8 p-6 md:p-12'>

--- a/src/pages/mypage/viewComments.tsx
+++ b/src/pages/mypage/viewComments.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
-import { getMyComments } from '../../api/mypage';
 import LoadingIndicator from '../../components/atoms/LoadingIndicator';
 import Button from '../../components/atoms/Button';
 import MyListItem from '../../components/molecules/MyListItem';
 import Pagination from '@/components/molecules/common/Pagination';
 import { FormatToDotDate } from '../../utils';
+import { useMyCommentsQuery } from '@/hooks/queries/useMyPageQueries';
 
 interface GroupedCommentPost {
   boardUuid: string;
@@ -26,55 +26,42 @@ const PAGE_SIZE = 10;
  */
 const ViewComments = () => {
   const [contents, setContents] = useState<GroupedCommentPost[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isError, setIsError] = useState(false);
 
   const [page, setPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
-
-  const fetchComments = async (currentPage: number) => {
-    try {
-      setIsLoading(true);
-      setIsError(false);
-
-      const res = await getMyComments(currentPage, PAGE_SIZE);
-      const grouped = res.content.reduce<Record<string, GroupedCommentPost>>((acc, cur) => {
-        const id = cur.boardUuid;
-
-        if (!acc[id]) {
-          acc[id] = {
-            boardUuid: cur.boardUuid,
-            boardTitle: cur.boardTitle,
-            boardPreviewContent: cur.boardPreviewContent,
-            boardViewCount: cur.boardViewCount,
-            boardLikeCount: cur.boardLikeCount,
-            boardCreatedAt: cur.boardCreatedAt,
-            comments: [],
-          };
-        }
-
-        if (cur.commentPreviewContent) {
-          acc[id].comments.push(cur.commentPreviewContent);
-        }
-
-        return acc;
-      }, {});
-
-      const groupedArray = Object.values(grouped);
-
-      setContents(groupedArray);
-      setTotalPages(res.totalPages);
-    } catch (e) {
-      console.error(e);
-      setIsError(true);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const { data, isLoading, isError } = useMyCommentsQuery(page, PAGE_SIZE);
 
   useEffect(() => {
-    void fetchComments(page);
-  }, [page]);
+    if (!data) {
+      setContents([]);
+      setTotalPages(0);
+      return;
+    }
+    const grouped = data.content.reduce<Record<string, GroupedCommentPost>>((acc, cur) => {
+      const id = cur.boardUuid;
+
+      if (!acc[id]) {
+        acc[id] = {
+          boardUuid: cur.boardUuid,
+          boardTitle: cur.boardTitle,
+          boardPreviewContent: cur.boardPreviewContent,
+          boardViewCount: cur.boardViewCount,
+          boardLikeCount: cur.boardLikeCount,
+          boardCreatedAt: cur.boardCreatedAt,
+          comments: [],
+        };
+      }
+
+      if (cur.commentPreviewContent) {
+        acc[id].comments.push(cur.commentPreviewContent);
+      }
+
+      return acc;
+    }, {});
+
+    setContents(Object.values(grouped));
+    setTotalPages(data.totalPages);
+  }, [data]);
 
   const handlePageChange = (nextPage: number) => {
     if (nextPage === page) return;

--- a/src/pages/mypage/viewLikes.tsx
+++ b/src/pages/mypage/viewLikes.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
-import { getMyLikedPosts, type MyPostItem } from '../../api/mypage';
+import { useState } from 'react';
 import Button from '../../components/atoms/Button';
 import MyListItem from '../../components/molecules/MyListItem';
 import LoadingIndicator from '../../components/atoms/LoadingIndicator';
 import Pagination from '../../components/molecules/common/Pagination';
 import { FormatToDotDate } from '../../utils';
+import { useMyLikedPostsQuery } from '@/hooks/queries/useMyPageQueries';
 
 /**
  * 찜한 글 페이지
@@ -13,33 +13,10 @@ import { FormatToDotDate } from '../../utils';
  * 게시글 제목, 미리보기, 댓글 수, 좋아요 수, 작성 시간을 보여줍니다.
  */
 const ViewLikedPosts = () => {
-  const [contents, setContents] = useState<MyPostItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isError, setIsError] = useState(false);
-
   const [page, setPage] = useState(0);
-  const [totalPages, setTotalPages] = useState(0);
-
-  const fetchLikedPosts = async (currentPage: number) => {
-    try {
-      setIsLoading(true);
-      setIsError(false);
-
-      const pageResult = await getMyLikedPosts(currentPage, 10);
-
-      setContents(pageResult.content);
-      setTotalPages(pageResult.totalPages);
-    } catch (e) {
-      console.error(e);
-      setIsError(true);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    void fetchLikedPosts(page);
-  }, [page]);
+  const { data, isLoading, isError } = useMyLikedPostsQuery(page, 10);
+  const contents = data?.content ?? [];
+  const totalPages = data?.totalPages ?? 0;
 
   const handlePageChange = (nextPage: number) => {
     if (nextPage === page) return;

--- a/src/pages/mypage/viewPosts.tsx
+++ b/src/pages/mypage/viewPosts.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
-import { getMyPosts, type MyPostItem } from '../../api/mypage';
+import { useState } from 'react';
 import LoadingIndicator from '../../components/atoms/LoadingIndicator';
 import Button from '../../components/atoms/Button';
 import MyListItem from '../../components/molecules/MyListItem';
 import Pagination from '@/components/molecules/common/Pagination';
 import { FormatToDotDate } from '@/utils';
+import { useMyPostsQuery } from '@/hooks/queries/useMyPageQueries';
 
 /**
  * 내가 쓴 게시물 페이지
@@ -13,32 +13,10 @@ import { FormatToDotDate } from '@/utils';
  * 게시글 제목, 미리보기, 댓글 수, 좋아요 수, 작성 시간을 보여줍니다.
  */
 const ViewPosts = () => {
-  const [contents, setContents] = useState<MyPostItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isError, setIsError] = useState(false);
-
   const [page, setPage] = useState(0);
-  const [totalPages, setTotalPages] = useState(0);
-
-  const fetchPosts = async (currentPage: number) => {
-    try {
-      setIsLoading(true);
-      setIsError(false);
-      const pageResult = await getMyPosts(currentPage, 10);
-
-      setContents(pageResult.content);
-      setTotalPages(pageResult.totalPages);
-    } catch (e) {
-      console.error(e);
-      setIsError(true);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    void fetchPosts(page);
-  }, [page]);
+  const { data, isLoading, isError } = useMyPostsQuery(page, 10);
+  const contents = data?.content ?? [];
+  const totalPages = data?.totalPages ?? 0;
 
   const handlePageChange = (nextPage: number) => {
     if (nextPage === page) return;

--- a/src/pages/search/SearchDetailOverlay.tsx
+++ b/src/pages/search/SearchDetailOverlay.tsx
@@ -3,12 +3,6 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import { useHeaderStore } from '@/store/useHeaderStore';
 import { IoMdLink, IoIosArrowUp, IoIosArrowDown, IoIosClose, IoIosMenu } from 'react-icons/io';
-import {
-  getSearchAISummary,
-  getSearchResult,
-  type GetSearchAISummaryRes,
-  type SearchResultItemRes,
-} from '../../api/search';
 import type { Category } from '@/api/search';
 import { setHomeSliderToMain } from '@/pages/HomeSlider';
 import { ScrollableTap } from '@/components/atoms/scrollableTap/index';
@@ -17,11 +11,23 @@ import ListEntry, { type SearchTabKey } from './ListEntry';
 import { Skeleton } from '@/components/atoms/Skeleton';
 import SidebarV2 from '@/components/organisms/SidebarV2';
 import SearchBar from '../../components/atoms/SearchBar';
-
 import { useNavTracking } from '@/hooks/gtm/useNavTracking';
 import { resolveNavGroupByLabel } from '@/constants/gtm.ts';
+import {
+  useAllSearchQueries,
+  useAiSummaryQuery,
+  useSearchQuery,
+} from '@/hooks/queries/useSearchQueries';
+import type { SearchResultItemRes } from '@/api/search';
 
-type SearchResultType = Parameters<typeof getSearchResult>[1];
+type SearchResultType =
+  | 'NOTICE'
+  | 'MJU_CALENDAR'
+  | 'DEPARTMENT_NOTICE'
+  | 'COMMUNITY'
+  | 'NEWS'
+  | 'BROADCAST'
+  | 'ALL';
 
 const tapLabel: Record<string, SearchResultType | 'ALL'> = {
   ALL: 'ALL',
@@ -37,7 +43,6 @@ function getNoticeSectionMorePath() {
   return '/search';
 }
 
-/** 더보기 링크의 search 문자열 (? 포함) */
 function getNoticeSectionMoreSearch(tab: SearchTabKey, keyword: string) {
   const params = new URLSearchParams();
   params.set('keyword', keyword);
@@ -45,14 +50,17 @@ function getNoticeSectionMoreSearch(tab: SearchTabKey, keyword: string) {
   return `?${params.toString()}`;
 }
 
-/**
- * 모바일 검색 결과 페이지
- *
- * 통합 검색 결과를 표시하는 페이지입니다.
- * 공지사항, 자유게시판, 명대신문 검색 결과를 한 번에 보여줍니다.
- */
 function isValidTab(tab: string | null): tab is SearchTabKey {
   return tab !== null && tapLabel[tab] !== undefined;
+}
+
+function sliceByType(
+  content: SearchResultItemRes[] | undefined,
+  type: string,
+  limit: number,
+): SearchResultItemRes[] {
+  if (!content) return [];
+  return content.filter((item) => item.type?.toLowerCase() === type.toLowerCase()).slice(0, limit);
 }
 
 export default function SearchDetail() {
@@ -65,33 +73,18 @@ export default function SearchDetail() {
   });
   const [categoryTab, setCategoryTab] = useState<Category | string>('all');
   const [isLinkOpen, setIsLinkOpen] = useState(false);
-  const [noticeItems, setNoticeItems] = useState<SearchResultItemRes[]>([]);
-  const [boardItems, setBoardItems] = useState<SearchResultItemRes[]>([]);
-  const [newsItems, setNewsItems] = useState<SearchResultItemRes[]>([]);
-  const [broadcastItems, setBroadcastItems] = useState<SearchResultItemRes[]>([]);
-  const [items, setItems] = useState<SearchResultItemRes[]>([]);
-  const pageFromUrl = parseInt(searchParams.get('page') || '1', 10);
-  const page = pageFromUrl > 0 ? pageFromUrl - 1 : 0;
-  const [totalPages, setTotalPages] = useState(1);
+  const [sort, setSort] = useState<Sort>('relevance');
   const [isOpen, setIsOpen] = useState(false);
   const toggleMenu = () => setIsOpen((p) => !p);
   const closeMenu = () => setIsOpen(false);
 
-  const [aiSummary, setAiSummary] = useState<GetSearchAISummaryRes>({
-    query: '',
-    summary: '',
-    document_count: 0,
-    sources: [],
-  });
-  const [initialContent, setInitialContent] = useState('');
-  const [sort, setSort] = useState<Sort>('relevance');
-  const [isAiSummaryLoading, setIsAiSummaryLoading] = useState(false);
+  const pageFromUrl = parseInt(searchParams.get('page') || '1', 10);
+  const page = pageFromUrl > 0 ? pageFromUrl - 1 : 0;
 
   const keyword = searchParams.get('keyword');
 
   const { trackNavClick } = useNavTracking();
 
-  /** URL의 tab 쿼리와 동기화 (ALL이면 tab 파라미터 없음) */
   useEffect(() => {
     const tab = searchParams.get('tab');
     if (isValidTab(tab) && tab !== currentTab) setCurrentTab(tab);
@@ -100,86 +93,16 @@ export default function SearchDetail() {
   const handleSetCurrentTab = (tab: string) => {
     if (!isValidTab(tab)) return;
     setCurrentTab(tab);
+    setSort('relevance');
+    if (tab !== '게시판' && tab !== '학사일정') setCategoryTab('all');
+    else if (tab === '게시판') setCategoryTab('NOTICE');
+    else if (tab === '학사일정') setCategoryTab('MJU_CALENDAR');
     const next = new URLSearchParams(searchParams);
     if (tab === 'ALL') next.delete('tab');
     else next.set('tab', tab);
+    next.set('page', '1');
     setSearchParams(next, { replace: true });
   };
-
-  /**
-   * 검색 요청 function
-   */
-  const filterByType = (content: SearchResultItemRes[], type: string) =>
-    content
-      .filter((item) => item.type?.toLowerCase() === type.toLowerCase())
-      .slice(0, type === 'broadcast' ? 2 : 5);
-
-  async function handleSearch(text: string) {
-    if (currentTab === 'ALL' || tapLabel[currentTab] === 'ALL') {
-      const noticeRes = await getSearchResult(text, 'NOTICE', 'all', sort);
-      const communityRes = await getSearchResult(text, 'COMMUNITY', 'all', sort);
-      const newsRes = await getSearchResult(text, 'NEWS', 'all', sort);
-      const broadcastRes = await getSearchResult(text, 'BROADCAST', 'all', sort);
-      const noticeContent = noticeRes.content as unknown as SearchResultItemRes[];
-      const communityContent = communityRes.content as unknown as SearchResultItemRes[];
-      const newsContent = newsRes.content as unknown as SearchResultItemRes[];
-      const broadcastContent = broadcastRes.content as unknown as SearchResultItemRes[];
-      setNoticeItems(filterByType(noticeContent, 'notice'));
-      setBoardItems(filterByType(communityContent, 'community'));
-      setNewsItems(filterByType(newsContent, 'news'));
-      setBroadcastItems(filterByType(broadcastContent, 'broadcast'));
-    } else {
-      let type = tapLabel[currentTab];
-      if (currentTab === '학사일정' && categoryTab === 'academic') type = 'NOTICE';
-      const category =
-        currentTab === '명대뉴스' || categoryTab === 'MJU_CALENDAR' ? 'all' : categoryTab;
-      const res = await getSearchResult(text, type, category, sort, page, 10);
-      const items = res.content as unknown as SearchResultItemRes[];
-      setItems(items);
-      setTotalPages(res.totalPages);
-    }
-  }
-
-  async function handleGetAiSummary(text: string) {
-    const res = await getSearchAISummary(text);
-    setAiSummary(res);
-  }
-
-  /**
-   * 페이지 변경 시 url과 함께 반영
-   */
-  const handlePageChange = (newPage: number) => {
-    const newParams = new URLSearchParams(searchParams);
-    newParams.set('page', String(newPage + 1));
-    setSearchParams(newParams);
-  };
-
-  /**
-   * 검색어 초기값 반영 (search parameter 반영)
-   */
-  useEffect(() => {
-    (async () => {
-      if (!keyword) {
-        setInitialContent('');
-        setIsAiSummaryLoading(false);
-        return;
-      }
-      setInitialContent(keyword);
-      setIsAiSummaryLoading(true);
-      try {
-        await handleSearch(keyword);
-      } catch {
-        // 에러는 상위에서 처리
-      }
-      try {
-        await handleGetAiSummary(keyword);
-      } catch {
-        setAiSummary((prev) => ({ ...prev, summary: '', document_count: 0, sources: [] }));
-      } finally {
-        setIsAiSummaryLoading(false);
-      }
-    })();
-  }, [keyword, page]);
 
   useEffect(() => {
     setSort('relevance');
@@ -189,24 +112,67 @@ export default function SearchDetail() {
   }, [keyword]);
 
   useEffect(() => {
-    handleSearch(keyword ?? '');
     const newParams = new URLSearchParams(searchParams);
     newParams.set('page', '1');
     setSearchParams(newParams);
   }, [sort, categoryTab]);
 
-  useEffect(() => {
-    setSort('relevance');
-    if (currentTab !== '게시판' && currentTab !== '학사일정') setCategoryTab('all');
-    else if (currentTab === '게시판') setCategoryTab('NOTICE');
-    else if (currentTab === '학사일정') setCategoryTab('MJU_CALENDAR');
-    handleSearch(keyword ?? '');
-  }, [currentTab]);
+  const handlePageChange = (newPage: number) => {
+    const newParams = new URLSearchParams(searchParams);
+    newParams.set('page', String(newPage + 1));
+    setSearchParams(newParams);
+  };
 
-  useEffect(() => {
-    if (currentTab !== '학사일정') return;
-    handleSearch(keyword ?? '');
-  }, [categoryTab]);
+  const isAllTab = currentTab === 'ALL';
+
+  // ALL 탭: 4가지 타입 병렬 조회
+  const allQueries = useAllSearchQueries(keyword, sort);
+  const [noticeQuery, communityQuery, newsQuery, broadcastQuery] = allQueries;
+
+  const noticeItems = sliceByType(
+    noticeQuery.data?.content as unknown as SearchResultItemRes[],
+    'notice',
+    5,
+  );
+  const boardItems = sliceByType(
+    communityQuery.data?.content as unknown as SearchResultItemRes[],
+    'community',
+    5,
+  );
+  const newsItems = sliceByType(
+    newsQuery.data?.content as unknown as SearchResultItemRes[],
+    'news',
+    5,
+  );
+  const broadcastItems = sliceByType(
+    broadcastQuery.data?.content as unknown as SearchResultItemRes[],
+    'broadcast',
+    2,
+  );
+
+  // 개별 탭: 단일 타입 조회
+  const singleTabType = (() => {
+    if (isAllTab) return 'NOTICE' as const; // enabled=false이므로 실제 호출 안 됨
+    let type = tapLabel[currentTab] as Exclude<SearchResultType, 'ALL'>;
+    if (currentTab === '학사일정' && categoryTab === 'academic') type = 'NOTICE';
+    return type;
+  })();
+  const singleCategory =
+    currentTab === '명대뉴스' || categoryTab === 'MJU_CALENDAR' ? 'all' : categoryTab;
+
+  const singleQuery = useSearchQuery(keyword, singleTabType, singleCategory, sort, page, !isAllTab);
+  const items = (singleQuery.data?.content as unknown as SearchResultItemRes[]) ?? [];
+  const totalPages = singleQuery.data?.totalPages ?? 1;
+
+  // AI 요약
+  const aiSummaryQuery = useAiSummaryQuery(keyword);
+  const aiSummary = aiSummaryQuery.data ?? {
+    query: '',
+    summary: '',
+    document_count: 0,
+    sources: [],
+  };
+  const isAiSummaryLoading = aiSummaryQuery.isLoading;
 
   return (
     <div className='fixed inset-0 z-50 flex justify-center bg-black/30'>
@@ -241,6 +207,7 @@ export default function SearchDetail() {
           </button>
         </header>
         <SidebarV2 isOpen={isOpen} onClose={closeMenu} />
+
         {/* 탭 */}
         <section>
           <ScrollableTap
@@ -263,8 +230,9 @@ export default function SearchDetail() {
             }}
           />
         </section>
+
         <div className='no-scrollbar flex min-h-0 flex-1 flex-col overflow-y-auto'>
-          {/* ai요약 */}
+          {/* AI 요약 */}
           {currentTab === 'ALL' && (
             <section className='border-grey-10 flex flex-col gap-3.5 border-b-1 p-5'>
               <div className='text-body02 flex w-full items-center text-black'>
@@ -343,6 +311,7 @@ export default function SearchDetail() {
               )}
             </section>
           )}
+
           {/* 검색결과 */}
           <ListEntry
             currentTab={currentTab}
@@ -352,7 +321,7 @@ export default function SearchDetail() {
             broadcastItems={broadcastItems}
             items={items}
             keyword={keyword}
-            initialContent={initialContent}
+            initialContent={keyword ?? ''}
             getMorePath={getNoticeSectionMorePath}
             getMoreSearch={getNoticeSectionMoreSearch}
             sort={sort}

--- a/src/pages/search/SearchOverlay.tsx
+++ b/src/pages/search/SearchOverlay.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router-dom';
 
 import SearchBar from '@/components/atoms/SearchBar';
 import { useEffect, useState } from 'react';
-import { getRealTimeSearch } from '@/api/main/real-time';
 import {
   addRecentKeyword,
   clearRecentKeywords,
@@ -12,6 +11,7 @@ import {
   removeRecentKeyword,
 } from '@/utils/recentSearch';
 import { useAuthStore } from '@/store/useAuthStore';
+import { useRealtimeKeywordQuery } from '@/hooks/queries/useRealtimeKeywordQuery';
 
 function goToSearch(navigate: ReturnType<typeof useNavigate>, keyword: string, scope?: string) {
   addRecentKeyword(keyword, undefined, scope);
@@ -24,13 +24,11 @@ export default function SearchOverlay() {
   const recentSearchScope = user?.uuid ?? undefined;
   const [searchHistory, setSearchHistory] = useState<string[]>([]);
   const recommendedKeywords = ['장학금', '명대신문', '학번', '중간고사', '축제'];
-  const [hotKeywords, setHotKeywords] = useState<string[]>([]);
+  const { data: hotKeywordData } = useRealtimeKeywordQuery(6);
+  const hotKeywords = hotKeywordData?.data ?? [];
 
   useEffect(() => {
     setSearchHistory(loadRecentKeywords(recentSearchScope));
-    getRealTimeSearch(6).then((res) => {
-      setHotKeywords(res.data);
-    });
   }, [recentSearchScope]);
 
   return (


### PR DESCRIPTION
## 변경 목적
기존 useEffect 기반 fetch 구조에서 동일 조건 API가 중복 호출되는 구간이 존재해,
서버 통신 부하와 불필요한 재요청 비용이 발생하고 있었습니다.

이번 PR은 UI/UX를 유지한 채 데이터 조회 레이어를 TanStack Query로 전환하여
중복 호출 제거, 캐시 재사용, 재요청 정책 표준화를 적용합니다.

## 핵심 변경 사항

### 1) 전역 Query 정책 적용
- QueryClient defaultOptions 설정
  - refetchOnWindowFocus: false
  - retry: 1
  - gcTime: 10m
- 도메인별 staleTime 상수 추가
  - search, suggest, ai-summary, notice, board, news, broadcast, department 계열

### 2) 검색 영역 리팩토링
- 통합검색 상세(/search) 조회 로직을 useEffect -> useQuery/useQueries로 전환
- ALL 탭 4개 도메인(공지/게시판/신문/뉴스) 병렬 조회를 query key로 관리
- 탭/카테고리/정렬/페이지/키워드 조합 기준 캐시 재사용
- 자동완성 API에 AbortSignal 전달하여 불필요한 in-flight 요청 취소

### 3) 메인 섹션 리팩토링
- 공지사항, 게시판, 명대신문, 명대뉴스 섹션 fetch를 공통 Query Hook으로 전환
- 동일 key 요청 dedupe 및 staleTime 기반 재조회 최소화

### 4) 학과 페이지 리팩토링
- 학과 정보/일정/공지를 useQuery로 전환
- 학생회 공지는 useInfiniteQuery로 전환하여 페이지 단위 캐싱
- 필터 변경 시 필요한 쿼리만 재호출되도록 정리

## 예상 효과
- 검색 상세 첫 진입/탭 변경 시 중복 호출 감소
- 동일 조건 재방문 시 캐시 히트로 백엔드 호출 절감
- API 요청량 감소로 월간 AWS 비용 절감 기대

