### PR TITLE
<Fix> TanStack Query 리팩토링 확장 적용 (Broadcast/Board Detail/MyPage/Search Overlay) 및 Footer GitHub 링크 수정

### DIFF
--- a/src/components/organisms/Footer/index.tsx
+++ b/src/components/organisms/Footer/index.tsx
@@ -9,7 +9,7 @@ export default function Footer() {
         <div className='text-blue-10 flex items-center gap-3'>
           {/* 깃 아이콘 */}
           <a
-            href='https://github.com/NOVA-MJU/THINGO_BACKEND'
+            href='https://github.com/NOVA-MJU'
             target='_blank'
             rel='noopener noreferrer'
             aria-label='깃허브'

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -23,6 +23,11 @@ export const DEPARTMENT_NOTICE_STALE_TIME_MS = 5 * 60 * 1000;
 export const SEARCH_STALE_TIME_MS = 2 * 60 * 1000;
 export const SEARCH_SUGGEST_STALE_TIME_MS = 60 * 1000;
 export const AI_SUMMARY_STALE_TIME_MS = 10 * 60 * 1000;
+export const BROADCAST_SEARCH_STALE_TIME_MS = 2 * 60 * 1000;
+export const BOARD_DETAIL_STALE_TIME_MS = 2 * 60 * 1000;
+export const BOARD_COMMENTS_STALE_TIME_MS = 60 * 1000;
+export const MYPAGE_STALE_TIME_MS = 5 * 60 * 1000;
+export const HOT_KEYWORDS_STALE_TIME_MS = 60 * 1000;
 
 export const ICON_SIZE_SM = 12;
 export const ICON_SIZE_MD = 16;

--- a/src/hooks/queries/useBoardDetailQueries.ts
+++ b/src/hooks/queries/useBoardDetailQueries.ts
@@ -1,0 +1,48 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { deletePost, getBoardComments, getBoardDetail, likePost, postComment } from '@/api/board';
+import { BOARD_COMMENTS_STALE_TIME_MS, BOARD_DETAIL_STALE_TIME_MS } from '@/constants/common';
+
+export function useBoardDetailQuery(uuid?: string) {
+  return useQuery({
+    queryKey: ['board-detail', uuid] as const,
+    queryFn: () => getBoardDetail(uuid!),
+    enabled: !!uuid,
+    staleTime: BOARD_DETAIL_STALE_TIME_MS,
+  });
+}
+
+export function useBoardCommentsQuery(uuid?: string, enabled: boolean = true) {
+  return useQuery({
+    queryKey: ['board-comments', uuid] as const,
+    queryFn: () => getBoardComments(uuid!),
+    enabled: !!uuid && enabled,
+    staleTime: BOARD_COMMENTS_STALE_TIME_MS,
+  });
+}
+
+export function usePostCommentMutation(uuid?: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (content: string) => postComment(uuid!, content),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['board-comments', uuid] });
+      queryClient.invalidateQueries({ queryKey: ['board-detail', uuid] });
+    },
+  });
+}
+
+export function useLikePostMutation(uuid?: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => likePost(uuid!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['board-detail', uuid] });
+    },
+  });
+}
+
+export function useDeletePostMutation(uuid?: string) {
+  return useMutation({
+    mutationFn: () => deletePost(uuid!),
+  });
+}

--- a/src/hooks/queries/useBroadcastPageQuery.ts
+++ b/src/hooks/queries/useBroadcastPageQuery.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchBroadcasts, searchBroadcasts } from '@/api/main/broadcast-api';
+import { BROADCAST_PAGE_SIZE, BROADCAST_SEARCH_STALE_TIME_MS } from '@/constants/common';
+
+export function useBroadcastListQuery(page: number, size: number = BROADCAST_PAGE_SIZE) {
+  return useQuery({
+    queryKey: ['broadcast-page', 'list', page, size] as const,
+    queryFn: () => fetchBroadcasts(page, size),
+    staleTime: BROADCAST_SEARCH_STALE_TIME_MS,
+    placeholderData: (prev) => prev,
+  });
+}
+
+export function useBroadcastSearchQuery(
+  keyword: string,
+  page: number,
+  size: number = BROADCAST_PAGE_SIZE,
+) {
+  return useQuery({
+    queryKey: ['broadcast-page', 'search', keyword, page, size] as const,
+    queryFn: () => searchBroadcasts(keyword, 'relevance', page, size),
+    enabled: !!keyword.trim(),
+    staleTime: BROADCAST_SEARCH_STALE_TIME_MS,
+    placeholderData: (prev) => prev,
+  });
+}

--- a/src/hooks/queries/useMyPageQueries.ts
+++ b/src/hooks/queries/useMyPageQueries.ts
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  getMyComments,
+  getMyLikedPosts,
+  getMyPosts,
+  getProfileStats,
+  type MyCommentedPostItem,
+  type MyPostItem,
+  type ProfileStatsRes,
+} from '@/api/mypage';
+import { MYPAGE_STALE_TIME_MS } from '@/constants/common';
+import type { Paginated } from '@/api/types';
+
+export function useProfileStatsQuery() {
+  return useQuery<ProfileStatsRes>({
+    queryKey: ['mypage', 'stats'] as const,
+    queryFn: getProfileStats,
+    staleTime: MYPAGE_STALE_TIME_MS,
+  });
+}
+
+export function useMyPostsQuery(page: number, size: number = 10) {
+  return useQuery<Paginated<MyPostItem>>({
+    queryKey: ['mypage', 'posts', page, size] as const,
+    queryFn: () => getMyPosts(page, size),
+    staleTime: MYPAGE_STALE_TIME_MS,
+    placeholderData: (prev) => prev,
+  });
+}
+
+export function useMyCommentsQuery(page: number, size: number = 10) {
+  return useQuery<Paginated<MyCommentedPostItem>>({
+    queryKey: ['mypage', 'comments', page, size] as const,
+    queryFn: () => getMyComments(page, size),
+    staleTime: MYPAGE_STALE_TIME_MS,
+    placeholderData: (prev) => prev,
+  });
+}
+
+export function useMyLikedPostsQuery(page: number, size: number = 10) {
+  return useQuery<Paginated<MyPostItem>>({
+    queryKey: ['mypage', 'likes', page, size] as const,
+    queryFn: () => getMyLikedPosts(page, size),
+    staleTime: MYPAGE_STALE_TIME_MS,
+    placeholderData: (prev) => prev,
+  });
+}

--- a/src/hooks/queries/useRealtimeKeywordQuery.ts
+++ b/src/hooks/queries/useRealtimeKeywordQuery.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getRealTimeSearch } from '@/api/main/real-time';
+import { HOT_KEYWORDS_STALE_TIME_MS } from '@/constants/common';
+
+export function useRealtimeKeywordQuery(count: number = 6) {
+  return useQuery({
+    queryKey: ['search', 'realtime-keywords', count] as const,
+    queryFn: () => getRealTimeSearch(count),
+    staleTime: HOT_KEYWORDS_STALE_TIME_MS,
+  });
+}

--- a/src/pages/board/detail/index.tsx
+++ b/src/pages/board/detail/index.tsx
@@ -1,12 +1,4 @@
-import {
-  deletePost,
-  getBoardComments,
-  getBoardDetail,
-  likePost,
-  postComment,
-  type CommentRes,
-  type GetBoardDetailRes,
-} from '@/api/board';
+import { type CommentRes } from '@/api/board';
 import NavigationUp from '@/components/molecules/NavigationUp';
 import BlockTextEditor from '@/components/organisms/BlockTextEditor';
 import GlobalErrorPage from '@/pages/error';
@@ -20,19 +12,16 @@ import { useAuthStore } from '@/store/useAuthStore';
 import { handleError } from '@/utils/error';
 import { ChatBubbleIcon, HeartIcon } from '@/components/atoms/Icon';
 import { formatToDotDate } from '@/utils/date';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  useBoardCommentsQuery,
+  useBoardDetailQuery,
+  useDeletePostMutation,
+  useLikePostMutation,
+  usePostCommentMutation,
+} from '@/hooks/queries/useBoardDetailQueries';
 
 const MAX_REPLY_LEN = 100;
-
-interface BoardDetail {
-  id: string;
-  title: string;
-  date: string;
-  author: string;
-  viewCount: number;
-  commentCount: number;
-  likeCount: number;
-  content: string;
-}
 
 /**
  * 게시판 상세 페이지
@@ -44,55 +33,27 @@ interface BoardDetail {
 export default function BoardDetail() {
   const navigate = useNavigate();
   const { uuid } = useParams<{ uuid: string }>();
-  const [content, setContent] = useState<GetBoardDetailRes | null>(null);
-  const [comments, setComments] = useState<CommentRes[] | null>(null);
-  const [isContentLoading, setIsContentLoading] = useState(true);
-  const [isCommentsLoading, setIsCommentsLoading] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [isCommentUploading, setIsCommentUploading] = useState(false);
   const [newComment, setNewComment] = useState('');
   const [isError, setIsError] = useState(false);
   const { isLoggedIn } = useAuthStore();
+  const queryClient = useQueryClient();
+  const contentQuery = useBoardDetailQuery(uuid);
+  const commentsQuery = useBoardCommentsQuery(uuid, isLoggedIn);
+  const postCommentMutation = usePostCommentMutation(uuid);
+  const likePostMutation = useLikePostMutation(uuid);
+  const deletePostMutation = useDeletePostMutation(uuid);
+  const content = contentQuery.data ?? null;
+  const comments: CommentRes[] | null = isLoggedIn ? (commentsQuery.data ?? []) : null;
+  const isContentLoading = contentQuery.isLoading;
+  const isCommentsLoading = isLoggedIn ? commentsQuery.isLoading : false;
 
-  // 페이지 로드 함수 (로그인된 경우에만 댓글 API 조회)
   useEffect(() => {
-    if (!uuid) return;
-    getContent(uuid);
-    if (isLoggedIn) {
-      getComments(uuid);
-    } else {
-      setComments(null);
-      setIsCommentsLoading(false);
-    }
-  }, [uuid, isLoggedIn]);
-
-  // 게시글 데이터 로드
-  const getContent = async (uuid: string) => {
-    setIsContentLoading(true);
-    try {
-      const res = await getBoardDetail(uuid);
-      setContent(res);
-    } catch (e) {
-      handleError(e, '게시글을 불러오는 중 오류가 발생했습니다.', { showToast: false });
+    if (contentQuery.isError || commentsQuery.isError) {
       setIsError(true);
-    } finally {
-      setIsContentLoading(false);
     }
-  };
-
-  // 댓글 데이터 로드
-  const getComments = async (uuid: string) => {
-    setIsCommentsLoading(true);
-    try {
-      const res = await getBoardComments(uuid);
-      setComments(res);
-    } catch (e) {
-      handleError(e, '댓글을 불러오는 중 오류가 발생했습니다.', { showToast: false });
-      setIsError(true);
-    } finally {
-      setIsCommentsLoading(false);
-    }
-  };
+  }, [contentQuery.isError, commentsQuery.isError]);
 
   // 댓글 작성 요청
   const handleCommentUpload = async () => {
@@ -108,8 +69,7 @@ export default function BoardDetail() {
 
     try {
       setIsCommentUploading(true);
-      await postComment(uuid, newComment);
-      await getComments(uuid);
+      await postCommentMutation.mutateAsync(newComment);
       setNewComment('');
     } catch (err) {
       handleError(err, '댓글 작성에 실패했습니다.');
@@ -128,16 +88,9 @@ export default function BoardDetail() {
     }
     setIsLoading(true);
     try {
-      await likePost(uuid);
       const wasLiked = content.isLiked;
-      setContent((prev) => {
-        if (!prev) return null;
-        return {
-          ...prev,
-          likeCount: prev.isLiked ? prev.likeCount - 1 : prev.likeCount + 1,
-          isLiked: !prev.isLiked,
-        };
-      });
+      await likePostMutation.mutateAsync();
+      await queryClient.invalidateQueries({ queryKey: ['board-detail', uuid] });
       if (!wasLiked) {
         toast.success('좋아요를 표시했습니다.');
       }
@@ -154,7 +107,7 @@ export default function BoardDetail() {
     if (!window.confirm('게시글을 삭제하시겠습니까?')) return;
     try {
       setIsLoading(true);
-      await deletePost(uuid);
+      await deletePostMutation.mutateAsync();
       toast.success('게시글이 삭제되었습니다.');
       navigate(-1);
     } catch (err) {

--- a/src/pages/broadcast/index.tsx
+++ b/src/pages/broadcast/index.tsx
@@ -1,13 +1,17 @@
 import { Link, useSearchParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { formatToLocalDate } from '@/utils';
-import { fetchBroadcasts, searchBroadcasts, type BroadcastItem } from '@/api/main/broadcast-api';
+import { type BroadcastItem } from '@/api/main/broadcast-api';
 import LoadingIndicator from '@/components/atoms/LoadingIndicator';
 import Pagination from '@/components/molecules/common/Pagination';
 import { useResponsive } from '@/hooks/useResponse';
 import SearchBar from '@/components/atoms/SearchBar';
 import { HighlightedText } from '@/components/atoms/HighlightedText';
 import { BROADCAST_PAGE_SIZE } from '@/constants/common';
+import {
+  useBroadcastListQuery,
+  useBroadcastSearchQuery,
+} from '@/hooks/queries/useBroadcastPageQuery';
 
 /**
  * 명대방송 페이지
@@ -22,10 +26,9 @@ export default function Broadcast() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [initialKeyword, setInitialKeyword] = useState('');
   const keyword = searchParams.get('keyword');
-  const [totalPage, setTotalPage] = useState(1);
   const page = Number(searchParams.get('page') || '0');
-  const [contents, setContents] = useState<BroadcastItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const normalizedKeyword = (keyword ?? '').trim();
+  const hasKeyword = normalizedKeyword.length > 0;
 
   /**
    * 페이지 번호를 url에 반영합니다
@@ -44,43 +47,16 @@ export default function Broadcast() {
     else setInitialKeyword('');
   }, [keyword]);
 
-  useEffect(() => {
-    /**
-     * 검색어 없는 경우 모든 데이터 조회
-     */
-    if (!keyword) {
-      (async () => {
-        try {
-          setIsLoading(true);
-          const res = await fetchBroadcasts(page, BROADCAST_PAGE_SIZE);
-          setTotalPage(res.totalPages);
-          setContents(res.content);
-        } catch (err) {
-          console.error(err);
-        } finally {
-          setIsLoading(false);
-        }
-      })();
-    }
+  const listQuery = useBroadcastListQuery(page, BROADCAST_PAGE_SIZE);
+  const searchQuery = useBroadcastSearchQuery(normalizedKeyword, page, BROADCAST_PAGE_SIZE);
 
-    /**
-     * 검색어 있는 경우 검색 요청
-     */
-    if (keyword) {
-      (async () => {
-        try {
-          setIsLoading(true);
-          const res = await searchBroadcasts(keyword, 'relevance', page, BROADCAST_PAGE_SIZE);
-          setContents(res.data);
-          setTotalPage(res.totalPages);
-        } catch (e) {
-          console.error(e);
-        } finally {
-          setIsLoading(false);
-        }
-      })();
-    }
-  }, [page, keyword]);
+  const isLoading = hasKeyword ? searchQuery.isLoading : listQuery.isLoading;
+  const contents: BroadcastItem[] = hasKeyword
+    ? (searchQuery.data?.data ?? [])
+    : (listQuery.data?.content ?? []);
+  const totalPage = hasKeyword
+    ? (searchQuery.data?.totalPages ?? 1)
+    : (listQuery.data?.totalPages ?? 1);
 
   /**
    * 로딩 페이지

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -1,30 +1,15 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import ActivitiesSection from '../../components/organisms/Mypage/ActivitiesSection';
-import { getProfileStats, type ProfileStatsRes } from '../../api/mypage';
 import ProfileCard from '../../components/molecules/user/ProfileCard';
 import LabelButton from '../../components/atoms/Button/LabelButton';
-import { handleError } from '../../utils/error';
 import { useAuthStore } from '../../store/useAuthStore';
 import LoginErrorPage from '../LoginError';
+import { useProfileStatsQuery } from '@/hooks/queries/useMyPageQueries';
 
 const Mypage: React.FC = () => {
   const user = useAuthStore((state) => state.user);
-  const [stateData, setStateData] = useState<ProfileStatsRes | null>(null);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const data = await getProfileStats();
-        setStateData(data);
-      } catch (err) {
-        handleError(err, '마이페이지 데이터를 불러오는 중 오류가 발생했습니다.', {
-          showToast: false,
-        });
-      }
-    };
-    fetchData();
-  }, []);
+  const { data: stateData } = useProfileStatsQuery();
 
   return (
     <div className='bg-grey-02 flex w-full flex-1 flex-col gap-8 p-6 md:p-12'>

--- a/src/pages/mypage/viewComments.tsx
+++ b/src/pages/mypage/viewComments.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
-import { getMyComments } from '../../api/mypage';
 import LoadingIndicator from '../../components/atoms/LoadingIndicator';
 import Button from '../../components/atoms/Button';
 import MyListItem from '../../components/molecules/MyListItem';
 import Pagination from '@/components/molecules/common/Pagination';
 import { FormatToDotDate } from '../../utils';
+import { useMyCommentsQuery } from '@/hooks/queries/useMyPageQueries';
 
 interface GroupedCommentPost {
   boardUuid: string;
@@ -26,55 +26,42 @@ const PAGE_SIZE = 10;
  */
 const ViewComments = () => {
   const [contents, setContents] = useState<GroupedCommentPost[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isError, setIsError] = useState(false);
 
   const [page, setPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
-
-  const fetchComments = async (currentPage: number) => {
-    try {
-      setIsLoading(true);
-      setIsError(false);
-
-      const res = await getMyComments(currentPage, PAGE_SIZE);
-      const grouped = res.content.reduce<Record<string, GroupedCommentPost>>((acc, cur) => {
-        const id = cur.boardUuid;
-
-        if (!acc[id]) {
-          acc[id] = {
-            boardUuid: cur.boardUuid,
-            boardTitle: cur.boardTitle,
-            boardPreviewContent: cur.boardPreviewContent,
-            boardViewCount: cur.boardViewCount,
-            boardLikeCount: cur.boardLikeCount,
-            boardCreatedAt: cur.boardCreatedAt,
-            comments: [],
-          };
-        }
-
-        if (cur.commentPreviewContent) {
-          acc[id].comments.push(cur.commentPreviewContent);
-        }
-
-        return acc;
-      }, {});
-
-      const groupedArray = Object.values(grouped);
-
-      setContents(groupedArray);
-      setTotalPages(res.totalPages);
-    } catch (e) {
-      console.error(e);
-      setIsError(true);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const { data, isLoading, isError } = useMyCommentsQuery(page, PAGE_SIZE);
 
   useEffect(() => {
-    void fetchComments(page);
-  }, [page]);
+    if (!data) {
+      setContents([]);
+      setTotalPages(0);
+      return;
+    }
+    const grouped = data.content.reduce<Record<string, GroupedCommentPost>>((acc, cur) => {
+      const id = cur.boardUuid;
+
+      if (!acc[id]) {
+        acc[id] = {
+          boardUuid: cur.boardUuid,
+          boardTitle: cur.boardTitle,
+          boardPreviewContent: cur.boardPreviewContent,
+          boardViewCount: cur.boardViewCount,
+          boardLikeCount: cur.boardLikeCount,
+          boardCreatedAt: cur.boardCreatedAt,
+          comments: [],
+        };
+      }
+
+      if (cur.commentPreviewContent) {
+        acc[id].comments.push(cur.commentPreviewContent);
+      }
+
+      return acc;
+    }, {});
+
+    setContents(Object.values(grouped));
+    setTotalPages(data.totalPages);
+  }, [data]);
 
   const handlePageChange = (nextPage: number) => {
     if (nextPage === page) return;

--- a/src/pages/mypage/viewLikes.tsx
+++ b/src/pages/mypage/viewLikes.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
-import { getMyLikedPosts, type MyPostItem } from '../../api/mypage';
+import { useState } from 'react';
 import Button from '../../components/atoms/Button';
 import MyListItem from '../../components/molecules/MyListItem';
 import LoadingIndicator from '../../components/atoms/LoadingIndicator';
 import Pagination from '../../components/molecules/common/Pagination';
 import { FormatToDotDate } from '../../utils';
+import { useMyLikedPostsQuery } from '@/hooks/queries/useMyPageQueries';
 
 /**
  * 찜한 글 페이지
@@ -13,33 +13,10 @@ import { FormatToDotDate } from '../../utils';
  * 게시글 제목, 미리보기, 댓글 수, 좋아요 수, 작성 시간을 보여줍니다.
  */
 const ViewLikedPosts = () => {
-  const [contents, setContents] = useState<MyPostItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isError, setIsError] = useState(false);
-
   const [page, setPage] = useState(0);
-  const [totalPages, setTotalPages] = useState(0);
-
-  const fetchLikedPosts = async (currentPage: number) => {
-    try {
-      setIsLoading(true);
-      setIsError(false);
-
-      const pageResult = await getMyLikedPosts(currentPage, 10);
-
-      setContents(pageResult.content);
-      setTotalPages(pageResult.totalPages);
-    } catch (e) {
-      console.error(e);
-      setIsError(true);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    void fetchLikedPosts(page);
-  }, [page]);
+  const { data, isLoading, isError } = useMyLikedPostsQuery(page, 10);
+  const contents = data?.content ?? [];
+  const totalPages = data?.totalPages ?? 0;
 
   const handlePageChange = (nextPage: number) => {
     if (nextPage === page) return;

--- a/src/pages/mypage/viewPosts.tsx
+++ b/src/pages/mypage/viewPosts.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
-import { getMyPosts, type MyPostItem } from '../../api/mypage';
+import { useState } from 'react';
 import LoadingIndicator from '../../components/atoms/LoadingIndicator';
 import Button from '../../components/atoms/Button';
 import MyListItem from '../../components/molecules/MyListItem';
 import Pagination from '@/components/molecules/common/Pagination';
 import { FormatToDotDate } from '@/utils';
+import { useMyPostsQuery } from '@/hooks/queries/useMyPageQueries';
 
 /**
  * 내가 쓴 게시물 페이지
@@ -13,32 +13,10 @@ import { FormatToDotDate } from '@/utils';
  * 게시글 제목, 미리보기, 댓글 수, 좋아요 수, 작성 시간을 보여줍니다.
  */
 const ViewPosts = () => {
-  const [contents, setContents] = useState<MyPostItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isError, setIsError] = useState(false);
-
   const [page, setPage] = useState(0);
-  const [totalPages, setTotalPages] = useState(0);
-
-  const fetchPosts = async (currentPage: number) => {
-    try {
-      setIsLoading(true);
-      setIsError(false);
-      const pageResult = await getMyPosts(currentPage, 10);
-
-      setContents(pageResult.content);
-      setTotalPages(pageResult.totalPages);
-    } catch (e) {
-      console.error(e);
-      setIsError(true);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    void fetchPosts(page);
-  }, [page]);
+  const { data, isLoading, isError } = useMyPostsQuery(page, 10);
+  const contents = data?.content ?? [];
+  const totalPages = data?.totalPages ?? 0;
 
   const handlePageChange = (nextPage: number) => {
     if (nextPage === page) return;

--- a/src/pages/search/SearchOverlay.tsx
+++ b/src/pages/search/SearchOverlay.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router-dom';
 
 import SearchBar from '@/components/atoms/SearchBar';
 import { useEffect, useState } from 'react';
-import { getRealTimeSearch } from '@/api/main/real-time';
 import {
   addRecentKeyword,
   clearRecentKeywords,
@@ -12,6 +11,7 @@ import {
   removeRecentKeyword,
 } from '@/utils/recentSearch';
 import { useAuthStore } from '@/store/useAuthStore';
+import { useRealtimeKeywordQuery } from '@/hooks/queries/useRealtimeKeywordQuery';
 
 function goToSearch(navigate: ReturnType<typeof useNavigate>, keyword: string, scope?: string) {
   addRecentKeyword(keyword, undefined, scope);
@@ -24,13 +24,11 @@ export default function SearchOverlay() {
   const recentSearchScope = user?.uuid ?? undefined;
   const [searchHistory, setSearchHistory] = useState<string[]>([]);
   const recommendedKeywords = ['장학금', '명대신문', '학번', '중간고사', '축제'];
-  const [hotKeywords, setHotKeywords] = useState<string[]>([]);
+  const { data: hotKeywordData } = useRealtimeKeywordQuery(6);
+  const hotKeywords = hotKeywordData?.data ?? [];
 
   useEffect(() => {
     setSearchHistory(loadRecentKeywords(recentSearchScope));
-    getRealTimeSearch(6).then((res) => {
-      setHotKeywords(res.data);
-    });
   }, [recentSearchScope]);
 
   return (


### PR DESCRIPTION
## 변경 목적
기존 `useEffect + local state` 중심의 fetch 구조에서 동일 조건 API의 재호출/중복 호출 여지가 있어,
서버 통신 부하와 불필요 요청 비용이 발생하고 있었습니다.

이번 PR은 UI/UX는 유지한 채 데이터 조회 레이어를 TanStack Query로 전환해
캐시 재사용, 중복 호출 제거, 재요청 정책 표준화를 적용하는 것이 목적입니다.

## 핵심 변경 사항

### 1) 전역 Query 정책 및 상수 정리
- QueryClient `defaultOptions` 적용
  - `refetchOnWindowFocus: false`
  - `retry: 1`
  - `gcTime: 10m`
- 도메인별 `staleTime` 상수 확장
  - `broadcast-search`, `board-detail`, `board-comments`, `mypage`, `hot-keywords` 등

### 2) 남은 고효율 구간 Query 전환
- **Broadcast 페이지**
  - `useEffect` 직접 호출 제거
  - 목록/검색을 `useQuery 2개 + enabled 분기`로 전환
- **Board Detail 페이지**
  - 게시글 상세/댓글 조회를 `useQuery`로 전환
  - 댓글 작성/좋아요/삭제를 `useMutation`으로 전환
  - 성공 후 `invalidateQueries`로 필요한 데이터만 갱신
- **MyPage 4종**
  - `mypage/index`, `viewPosts`, `viewComments`, `viewLikes`를 Query 기반으로 전환
  - 페이지 이동/재진입 시 캐시 재사용
- **Search Overlay 인기검색어**
  - `getRealTimeSearch(6)`를 Query 캐싱(`staleTime`)으로 전환

### 3) Footer 링크 수정
- Footer GitHub 아이콘 링크를
  - 기존: `https://github.com/NOVA-MJU/THINGO_BACKEND`
  - 변경: `https://github.com/NOVA-MJU`

## 커밋 내역
1. `<Fix> 남은 화면용 탠스택 쿼리 훅 및 캐시 상수 추가`
2. `<Fix> 방송 상세 마이페이지 검색오버레이 데이터 조회를 쿼리로 전환`
3. `<Fix> 푸터 깃허브 링크를 NOVA-MJU 조직 페이지로 변경`

